### PR TITLE
Add org name to main NPM package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jseql-ffi",
+  "name": "@cipherstash/jseql-ffi",
   "version": "0.1.1-0",
   "description": "",
   "main": "./lib/index.cjs",


### PR DESCRIPTION
This change renames the main package from `jseql-ffi` to `@cipherstash/jseql-ffi`.

This is consistent with other packages in our org. This change should also fix up the release workflow since it's currently failing to publish the main package because the NPM token is scoped to not allow packages scoped outside the org.

Example of a failed release workflow: https://github.com/cipherstash/jseql-ffi/actions/runs/12404742465.