### PR TITLE
Fix optional deps by adding Neon prefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "type": "library",
     "org": "@cipherstash",
     "platforms": "common",
-    "load": "./src/load.cts"
+    "load": "./src/load.cts",
+    "prefix": "jseql-ffi-"
   },
   "devDependencies": {
     "@neon-rs/cli": "^0.1.82",


### PR DESCRIPTION
This change is an attempt to fix up optional dependencies of jseql-ffi by adding the `neon.prefix` property to package.json.

Neon has a seemingly undocumented feature where it will generate optional dependencies for a package based on supported platforms. However, the names of these dependencies are currenlty incorrect because they're generated without `jseql-ffi-` in their names. For example, instead of adding `@cipherstash/jseql-ffi-darwin-x64` as an optional dep, Neon currently generates `@cipherstash/darwin-x64`. This causes installing `jseql-ffi` in a dependent package (e.g. `jseql`) to log warnings about 404's for optional dependencies. Attempting to use `jseql-ffi` then fails with a runtime error because the native lib is missing.

Setting `neon.prefix` to `"jseql-ffi-"` in package.json should fix up the names that Neon generates for optional dependencies.

See:
- Published package with invalid optional dependencies: https://www.npmjs.com/package/@cipherstash/jseql-ffi/v/0.1.1-1?activeTab=code
- Source code that seems to generate the depency names: https://github.com/neon-bindings/neon-rs/blob/b92c01b4c297ed34ab90348c641b181f1a5b0b8b/src/manifest/src/cache/npm/npm.cts#L126