### PR TITLE
Cip 1244/use latest client builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ lib
 cargo.log
 cross.log
 mise.local.toml
+cipherstash.secret.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,14 +389,15 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.16.0"
+version = "0.17.0-pre"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801dcf4d54176bc6aa5f51e52e82d9755d5d46dfca8dded445e7862763565819"
+checksum = "aec2c7b34c430ce0995b31b90acaaf87fc9ee2e8b95e5d56d587415fc88f0f7e"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
  "async-mutex",
  "async-trait",
+ "base16ct",
  "base64",
  "base85",
  "blake3",
@@ -426,13 +433,15 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serdect",
  "sha2",
  "static_assertions",
  "thiserror 1.0.69",
+ "toml",
  "tracing",
  "url",
  "uuid",
- "winnow",
+ "winnow 0.6.20",
  "zeroize",
  "zerokms-protocol",
 ]
@@ -2304,6 +2313,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2331,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42f67da2385b51a5f9652db9c93d78aeaf7610bf5ec366080b6de810604af53"
+dependencies = [
+ "base16ct",
+ "serde",
+ "zeroize",
 ]
 
 [[package]]
@@ -2645,20 +2674,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.3",
 ]
 
 [[package]]
@@ -3164,6 +3210,15 @@ name = "winnow"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
 dependencies = [
  "memchr",
 ]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ $ npm run build
 
 This command uses the [@neon-rs/cli](https://www.npmjs.com/package/@neon-rs/cli) utility to assemble the binary Node addon from the output of `cargo`.
 
+## Local setup
+
+You can use the `stash` CLI tool to set up your local environment.
+
+You will be prompted to sign in or create an account and follow steps to create a keyset and client key.
+
+```sh
+brew install cipherstash/tap/stash
+stash setup
+```
+
 ## Exploring
 
 After building `protect-ffi`, you can explore its exports at the Node console.

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cipherstash-client = "0.16.0"
+cipherstash-client = "=0.17.0-pre"
 neon = "1"
 once_cell = "1.20.2"
 thiserror = "2.0.8"

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -92,7 +92,7 @@ async fn new_client_inner() -> Result<Client, Error> {
 }
 
 fn encrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    let client = (&**cx.argument::<JsBox<Client>>(0)?).clone();
+    let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let plaintext = cx.argument::<JsString>(1)?.value(&mut cx);
     let column_name = cx.argument::<JsString>(2)?.value(&mut cx);
     let lock_context = encryption_context_from_js_value(cx.argument_opt(3), &mut cx)?;
@@ -157,7 +157,7 @@ async fn encrypt_inner(
 }
 
 fn encrypt_bulk(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    let client = (&**cx.argument::<JsBox<Client>>(0)?).clone();
+    let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let plaintext_targets = plaintext_targets_from_js_array(cx.argument::<JsArray>(1)?, &mut cx)?;
     let service_token = service_token_from_js_value(cx.argument_opt(2), &mut cx)?;
 
@@ -210,7 +210,7 @@ async fn encrypt_bulk_inner(
 }
 
 fn decrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    let client = (&**cx.argument::<JsBox<Client>>(0)?).clone();
+    let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let ciphertext = cx.argument::<JsString>(1)?.value(&mut cx);
     let lock_context = encryption_context_from_js_value(cx.argument_opt(2), &mut cx)?;
     let service_token = service_token_from_js_value(cx.argument_opt(3), &mut cx)?;
@@ -250,7 +250,7 @@ async fn decrypt_inner(
 }
 
 fn decrypt_bulk(mut cx: FunctionContext) -> JsResult<JsPromise> {
-    let client = (&**cx.argument::<JsBox<Client>>(0)?).clone();
+    let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let ciphertexts = ciphertexts_from_js_array(cx.argument::<JsArray>(1)?, &mut cx)?;
     let service_token = service_token_from_js_value(cx.argument_opt(2), &mut cx)?;
 
@@ -427,7 +427,7 @@ fn plaintext_str_from_bytes(bytes: Vec<u8>) -> Result<String, Error> {
     match plaintext {
         Plaintext::Utf8Str(Some(ref inner)) => Ok(inner.clone()),
         _ => {
-            return Err(Error::Unimplemented(
+            Err(Error::Unimplemented(
                 "data types other than `Utf8Str`".to_string(),
             ))
         }

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1,7 +1,6 @@
 use cipherstash_client::{
     config::{
-        console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError,
-        zero_kms_config::ZeroKMSConfig,
+        console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError, zero_kms_config::ZeroKMSConfig, EnvSource, CIPHERSTASH_SECRET_TOML, CIPHERSTASH_TOML
     },
     credentials::{ServiceCredentials, ServiceToken},
     encryption::{
@@ -75,9 +74,11 @@ async fn new_client_inner() -> Result<Client, Error> {
     let console_config = ConsoleConfig::builder().with_env().build()?;
     let cts_config = CtsConfig::builder().with_env().build()?;
     let zerokms_config = ZeroKMSConfig::builder()
+        .add_source(EnvSource::default())
+        .add_source(CIPHERSTASH_SECRET_TOML)
+        .add_source(CIPHERSTASH_TOML)
         .console_config(&console_config)
         .cts_config(&cts_config)
-        .with_env()
         .build_with_client_key()?;
 
     let zerokms = Arc::new(zerokms_config.create_client());

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1,6 +1,7 @@
 use cipherstash_client::{
     config::{
-        console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError, zero_kms_config::ZeroKMSConfig, EnvSource, CIPHERSTASH_SECRET_TOML, CIPHERSTASH_TOML
+        console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError,
+        zero_kms_config::ZeroKMSConfig, EnvSource, CIPHERSTASH_SECRET_TOML, CIPHERSTASH_TOML,
     },
     credentials::{ServiceCredentials, ServiceToken},
     encryption::{
@@ -426,11 +427,9 @@ fn plaintext_str_from_bytes(bytes: Vec<u8>) -> Result<String, Error> {
 
     match plaintext {
         Plaintext::Utf8Str(Some(ref inner)) => Ok(inner.clone()),
-        _ => {
-            Err(Error::Unimplemented(
-                "data types other than `Utf8Str`".to_string(),
-            ))
-        }
+        _ => Err(Error::Unimplemented(
+            "data types other than `Utf8Str`".to_string(),
+        )),
     }
 }
 


### PR DESCRIPTION
* Updated to cipherstash-client 0.17.0-pre
* Uses the new builder sources so this can work with the config outputs generated by `stash setup`
* Fixed some lints and ran `cargo fmt`