### PR TITLE
feat(ci): add github app for git actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
+      actions: read
     outputs:
       dryrun: ${{ steps.dryrun.outputs.dryrun }}
       publish: ${{ steps.publish.outputs.publish }}
@@ -73,8 +75,16 @@ jobs:
             exit 1
           fi
           echo publish=true | tee -a $GITHUB_OUTPUT
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.PUBLISHER_APP_ID }}
+          private-key: ${{ secrets.PUBLISHER_SECRET_KEY }}
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
       - name: Setup Neon Environment
         uses: ./.github/actions/setup
         with:


### PR DESCRIPTION
Github actions that modify the main branch have issues with Github Rulesets:

```
remote: - Changes must be made through a pull request.        
remote: 
remote: - Commits must have verified signatures.        
remote:   Found 1 violation: 
```

This allows a Github app to bypass rulesets for Github actions.