### PR TITLE
Add Encrypt config and search indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,8 +1818,11 @@ name = "protect-ffi"
 version = "0.1.0"
 dependencies = [
  "cipherstash-client",
+ "hex",
  "neon",
  "once_cell",
+ "serde",
+ "serde_json",
  "thiserror 2.0.8",
  "tokio",
 ]
@@ -2245,9 +2248,9 @@ checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
 dependencies = [
  "serde_derive",
 ]
@@ -2273,9 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.218"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2284,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
 dependencies = [
  "itoa",
  "memchr",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Protect.js CipherStash Client FFI
 
-> [!IMPORTANT]  
+> [!IMPORTANT]
 > If you are looking to implement this package into your application please use the official [protect package](https://github.com/cipherstash/protectjs).
 
 This project provides the JS bindings for the CipherStash Client Rust SDK and is bootstrapped by [create-neon](https://www.npmjs.com/package/create-neon).
@@ -38,9 +38,9 @@ $ npm i
 $ npm run build
 $ node
 > const addon = require(".");
-> const client = await addon.newClient();
-> const ciphertext = await addon.encrypt(client, "plaintext", "column_name");
-> const plaintext = await addon.decrypt(client, ciphertext);
+> const client = await addon.newClient(JSON.stringify({v: 1, tables: {users: {email: {indexes: {ore: {}, match: {}, unique: {}}}}}}));
+> const ciphertext = await addon.encrypt(client, "plaintext", "email", "users");
+> const plaintext = await addon.decrypt(client, JSON.parse(ciphertext).c);
 > console.log({ciphertext, plaintext});
 ```
 

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -12,7 +12,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cipherstash-client = "=0.17.0-pre.1"
+hex = "0.4.3"
 neon = "1"
 once_cell = "1.20.2"
+serde = "1.0.218"
+serde_json = "1.0.139"
 thiserror = "2.0.8"
 tokio = { version = "1", features = ["full"] }

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -24,14 +24,6 @@ impl Identifier {
 
         Self { table, column }
     }
-
-    pub fn table(&self) -> &String {
-        &self.table
-    }
-
-    pub fn column(&self) -> &String {
-        &self.column
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -8,7 +8,9 @@ use std::{collections::HashMap, str::FromStr};
 
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Identifier {
+    #[serde(rename = "t")]
     pub table: String,
+    #[serde(rename = "c")]
     pub column: String,
 }
 

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -1,0 +1,489 @@
+use super::Error;
+use cipherstash_client::schema::{
+    column::{Index, IndexType, TokenFilter, Tokenizer},
+    ColumnConfig, ColumnType,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, str::FromStr};
+
+#[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub struct Identifier {
+    pub table: String,
+    pub column: String,
+}
+
+impl Identifier {
+    pub fn new<S>(table: S, column: S) -> Self
+    where
+        S: Into<String>,
+    {
+        let table = table.into();
+        let column = column.into();
+
+        Self { table, column }
+    }
+
+    pub fn table(&self) -> &String {
+        &self.table
+    }
+
+    pub fn column(&self) -> &String {
+        &self.column
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Tables(HashMap<String, Table>);
+
+impl IntoIterator for Tables {
+    type Item = (String, Table);
+    type IntoIter = std::collections::hash_map::IntoIter<String, Table>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct Table(HashMap<String, Column>);
+
+impl IntoIterator for Table {
+    type Item = (String, Column);
+    type IntoIter = std::collections::hash_map::IntoIter<String, Column>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+pub struct EncryptConfig {
+    #[serde(rename = "v")]
+    pub version: u32,
+    pub tables: Tables,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, PartialEq)]
+pub struct Column {
+    #[serde(default)]
+    cast_as: CastAs,
+    #[serde(default)]
+    indexes: Indexes,
+}
+
+#[derive(Debug, Default, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum CastAs {
+    BigInt,
+    Boolean,
+    Date,
+    Real,
+    Double,
+    Int,
+    SmallInt,
+    #[default]
+    Text,
+    #[serde(rename = "jsonb")]
+    JsonB,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq)]
+pub struct Indexes {
+    #[serde(rename = "ore")]
+    ore_index: Option<OreIndexOpts>,
+    #[serde(rename = "unique")]
+    unique_index: Option<UniqueIndexOpts>,
+    #[serde(rename = "match")]
+    match_index: Option<MatchIndexOpts>,
+    #[serde(rename = "ste_vec")]
+    ste_vec_index: Option<SteVecIndexOpts>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct OreIndexOpts {}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct MatchIndexOpts {
+    #[serde(default = "default_tokenizer")]
+    tokenizer: Tokenizer,
+    #[serde(default)]
+    token_filters: Vec<TokenFilter>,
+    #[serde(default = "default_k")]
+    k: usize,
+    #[serde(default = "default_m")]
+    m: usize,
+    #[serde(default)]
+    include_original: bool,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct SteVecIndexOpts {
+    prefix: String,
+}
+
+fn default_tokenizer() -> Tokenizer {
+    Tokenizer::Standard
+}
+
+fn default_k() -> usize {
+    6
+}
+
+fn default_m() -> usize {
+    2048
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
+pub struct UniqueIndexOpts {
+    #[serde(default)]
+    token_filters: Vec<TokenFilter>,
+}
+
+impl From<CastAs> for ColumnType {
+    fn from(value: CastAs) -> Self {
+        match value {
+            CastAs::BigInt => ColumnType::BigInt,
+            CastAs::SmallInt => ColumnType::SmallInt,
+            CastAs::Int => ColumnType::Int,
+            CastAs::Boolean => ColumnType::Boolean,
+            CastAs::Date => ColumnType::Date,
+            CastAs::Real | CastAs::Double => ColumnType::Float,
+            CastAs::Text => ColumnType::Utf8Str,
+            CastAs::JsonB => ColumnType::JsonB,
+        }
+    }
+}
+
+impl FromStr for EncryptConfig {
+    type Err = Error;
+
+    fn from_str(data: &str) -> Result<Self, Self::Err> {
+        let config = serde_json::from_str(data).map_err(Error::Parse)?;
+        Ok(config)
+    }
+}
+
+impl EncryptConfig {
+    pub fn to_config_map(self) -> HashMap<Identifier, ColumnConfig> {
+        let mut map = HashMap::new();
+        for (table_name, columns) in self.tables.into_iter() {
+            for (column_name, column) in columns.into_iter() {
+                // debug!(target: KEYSET, msg = "Configured column", table = table_name, column = column_name);
+                let column_config = column.into_column_config(&column_name);
+                let key = Identifier::new(&table_name, &column_name);
+                map.insert(key, column_config);
+            }
+        }
+        map
+    }
+}
+
+impl Column {
+    pub fn into_column_config(self, name: &String) -> ColumnConfig {
+        let mut config = ColumnConfig::build(name.to_string()).casts_as(self.cast_as.into());
+
+        if self.indexes.ore_index.is_some() {
+            config = config.add_index(Index::new_ore());
+        }
+
+        if let Some(opts) = self.indexes.match_index {
+            config = config.add_index(Index::new(IndexType::Match {
+                tokenizer: opts.tokenizer,
+                token_filters: opts.token_filters,
+                k: opts.k,
+                m: opts.m,
+                include_original: opts.include_original,
+            }));
+        }
+
+        if let Some(opts) = self.indexes.unique_index {
+            config = config.add_index(Index::new(IndexType::Unique {
+                token_filters: opts.token_filters,
+            }))
+        }
+
+        if let Some(SteVecIndexOpts { prefix }) = self.indexes.ste_vec_index {
+            config = config.add_index(Index::new(IndexType::SteVec { prefix }))
+        }
+
+        config
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn parse(json: serde_json::Value) -> HashMap<Identifier, ColumnConfig> {
+        serde_json::from_value::<EncryptConfig>(json)
+            .map(|config| config.to_config_map())
+            .unwrap()
+    }
+
+    #[test]
+    fn column_with_empty_options_gets_defaults() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {}
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(column.cast_type, ColumnType::Utf8Str);
+        assert!(column.indexes.is_empty());
+    }
+
+    #[test]
+    fn can_parse_column_with_cast_as() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "favourite_int": {
+                        "cast_as": "int"
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "favourite_int");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(column.cast_type, ColumnType::Int);
+        assert_eq!(column.name, "favourite_int");
+        assert!(column.indexes.is_empty());
+    }
+
+    #[test]
+    fn can_parse_empty_indexes() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {}
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert!(column.indexes.is_empty());
+    }
+
+    #[test]
+    fn can_parse_ore_index() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {
+                            "ore": {}
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(column.indexes[0].index_type, IndexType::Ore);
+    }
+
+    #[test]
+    fn can_parse_unique_index_with_defaults() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {
+                            "unique": {}
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(
+            column.indexes[0].index_type,
+            IndexType::Unique {
+                token_filters: vec![]
+            }
+        );
+    }
+
+    #[test]
+    fn can_parse_unique_index_with_token_filter() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {
+                            "unique": {
+                                "token_filters": [
+                                    {
+                                        "kind": "downcase"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(
+            column.indexes[0].index_type,
+            IndexType::Unique {
+                token_filters: vec![TokenFilter::Downcase]
+            }
+        );
+    }
+
+    #[test]
+    fn can_parse_match_index_with_defaults() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {
+                            "match": {}
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(
+            column.indexes[0].index_type,
+            IndexType::Match {
+                tokenizer: Tokenizer::Standard,
+                token_filters: vec![],
+                k: 6,
+                m: 2048,
+                include_original: false
+            }
+        );
+    }
+
+    #[test]
+    fn can_parse_match_index_with_all_opts_set() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "email": {
+                        "indexes": {
+                            "match": {
+                                "tokenizer": {
+                                    "kind": "ngram",
+                                    "token_length": 3,
+                                },
+                                "token_filters": [
+                                    {
+                                        "kind": "downcase"
+                                    }
+                                ],
+                                "k": 8,
+                                "m": 1024,
+                                "include_original": true
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "email");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(
+            column.indexes[0].index_type,
+            IndexType::Match {
+                tokenizer: Tokenizer::Ngram { token_length: 3 },
+                token_filters: vec![TokenFilter::Downcase],
+                k: 8,
+                m: 1024,
+                include_original: true
+            }
+        );
+    }
+
+    #[test]
+    fn can_parse_ste_vec_index() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "users": {
+                    "event_data": {
+                        "indexes": {
+                            "ste_vec": {
+                                "prefix": "event-data"
+                            }
+                        }
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("users", "event_data");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(
+            column.indexes[0].index_type,
+            IndexType::SteVec {
+                prefix: "event-data".into()
+            },
+        );
+    }
+}

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -168,7 +168,6 @@ impl EncryptConfig {
         let mut map = HashMap::new();
         for (table_name, columns) in self.tables.into_iter() {
             for (column_name, column) in columns.into_iter() {
-                // debug!(target: KEYSET, msg = "Configured column", table = table_name, column = column_name);
                 let column_config = column.into_column_config(&column_name);
                 let key = Identifier::new(&table_name, &column_name);
                 map.insert(key, column_config);

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -5,16 +5,21 @@ use cipherstash_client::{
     },
     credentials::{ServiceCredentials, ServiceToken},
     encryption::{
-        Encrypted, EncryptionError, Plaintext, PlaintextTarget, ReferencedPendingPipeline,
-        ScopedCipher, TypeParseError,
+        self, EncryptionError, IndexTerm, Plaintext, PlaintextTarget, ReferencedPendingPipeline,
+        ScopedCipher, SteVec, TypeParseError,
     },
     schema::ColumnConfig,
-    zerokms::{self, EncryptedRecord, WithContext, ZeroKMSWithClientKey},
+    zerokms::{self, encrypted_record, EncryptedRecord, WithContext, ZeroKMSWithClientKey},
 };
+use encrypt_config::{EncryptConfig, Identifier};
 use neon::prelude::*;
 use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::{collections::HashMap, str::FromStr};
 use tokio::runtime::Runtime;
+
+mod encrypt_config;
 
 // Return a global tokio runtime or create one if it doesn't exist.
 // Throws a JavaScript exception if the `Runtime` fails to create.
@@ -28,9 +33,39 @@ fn runtime<'a, C: Context<'a>>(cx: &mut C) -> NeonResult<&'static Runtime> {
 struct Client {
     cipher: Arc<ScopedZeroKMSNoRefresh>,
     zerokms: Arc<ZeroKMSWithClientKey<ServiceCredentials>>,
+    encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
 }
 
 impl Finalize for Client {}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "k")]
+pub enum Encrypted {
+    #[serde(rename = "ct")]
+    Ciphertext {
+        #[serde(rename = "c", with = "encrypted_record::formats::mp_base85")]
+        ciphertext: EncryptedRecord,
+        #[serde(rename = "o")]
+        ore_index: Option<Vec<String>>,
+        #[serde(rename = "m")]
+        match_index: Option<Vec<u16>>,
+        #[serde(rename = "u")]
+        unique_index: Option<String>,
+        #[serde(rename = "i")]
+        identifier: Identifier,
+        #[serde(rename = "v")]
+        version: u16,
+    },
+    #[serde(rename = "sv")]
+    SteVec {
+        #[serde(rename = "sv")]
+        ste_vec_index: SteVec<16>,
+        #[serde(rename = "i")]
+        identifier: Identifier,
+        #[serde(rename = "v")]
+        version: u16,
+    },
+}
 
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
@@ -48,18 +83,34 @@ pub enum Error {
     Base85(String),
     #[error("unimplemented: {0} not supported yet by protect-ffi")]
     Unimplemented(String),
+    #[error(transparent)]
+    Parse(#[from] serde_json::Error),
+    #[error("column {}.{} not found in Encrypt config", _0.column, _0.table)]
+    UnknownColumn(Identifier),
 }
 
 type ScopedZeroKMSNoRefresh = ScopedCipher<ServiceCredentials>;
 
 fn new_client(mut cx: FunctionContext) -> JsResult<JsPromise> {
+    let encrypt_config: EncryptConfig = {
+        if let Some(schema) = cx.argument_opt(0) {
+            let schema_str = schema
+                .downcast_or_throw::<JsString, FunctionContext>(&mut cx)?
+                .value(&mut cx);
+
+            EncryptConfig::from_str(&schema_str).or_else(|err| cx.throw_error(err.to_string()))?
+        } else {
+            todo!("handle missing encrypt config arg")
+        }
+    };
+
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
 
     let (deferred, promise) = cx.promise();
 
     rt.spawn(async move {
-        let client_result = new_client_inner().await;
+        let client_result = new_client_inner(encrypt_config).await;
 
         deferred.settle_with(&channel, move |mut cx| {
             let client = client_result.or_else(|err| cx.throw_error(err.to_string()))?;
@@ -71,7 +122,7 @@ fn new_client(mut cx: FunctionContext) -> JsResult<JsPromise> {
     Ok(promise)
 }
 
-async fn new_client_inner() -> Result<Client, Error> {
+async fn new_client_inner(encrypt_config: EncryptConfig) -> Result<Client, Error> {
     let console_config = ConsoleConfig::builder().with_env().build()?;
     let cts_config = CtsConfig::builder().with_env().build()?;
     let zerokms_config = ZeroKMSConfig::builder()
@@ -90,15 +141,19 @@ async fn new_client_inner() -> Result<Client, Error> {
     Ok(Client {
         cipher: Arc::new(cipher),
         zerokms,
+        encrypt_config: Arc::new(encrypt_config.to_config_map()),
     })
 }
 
 fn encrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let plaintext = cx.argument::<JsString>(1)?.value(&mut cx);
+    // TODO: consider making column config an arg instead.
     let column_name = cx.argument::<JsString>(2)?.value(&mut cx);
-    let lock_context = encryption_context_from_js_value(cx.argument_opt(3), &mut cx)?;
-    let service_token = service_token_from_js_value(cx.argument_opt(4), &mut cx)?;
+    let table_name = cx.argument::<JsString>(3)?.value(&mut cx);
+
+    let lock_context = encryption_context_from_js_value(cx.argument_opt(5), &mut cx)?;
+    let service_token = service_token_from_js_value(cx.argument_opt(6), &mut cx)?;
 
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();
@@ -114,8 +169,15 @@ fn encrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
     //
     // This task will _not_ block the JavaScript main thread.
     rt.spawn(async move {
-        let ciphertext_result =
-            encrypt_inner(client, plaintext, column_name, lock_context, service_token).await;
+        let ciphertext_result = encrypt_inner(
+            client,
+            plaintext,
+            column_name,
+            table_name,
+            lock_context,
+            service_token,
+        )
+        .await;
 
         // Settle the promise from the result of a closure. JavaScript exceptions
         // will be converted to a Promise rejection.
@@ -137,10 +199,17 @@ async fn encrypt_inner(
     client: Client,
     plaintext: String,
     column_name: String,
+    table_name: String,
     encryption_context: Vec<zerokms::Context>,
     service_token: Option<ServiceToken>,
 ) -> Result<String, Error> {
-    let column_config = ColumnConfig::build(column_name);
+    let ident = Identifier::new(table_name, column_name);
+
+    let column_config = client
+        .encrypt_config
+        .get(&ident)
+        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+
     let mut pipeline = ReferencedPendingPipeline::new(client.cipher);
     let mut encryptable = PlaintextTarget::new(plaintext, column_config.clone());
     encryptable.context = encryption_context;
@@ -155,7 +224,9 @@ async fn encrypt_inner(
         )
     })?;
 
-    mp_base85_str_from_encrypted(encrypted)
+    let eql_payload = to_eql_encrypted(encrypted, &ident).unwrap();
+
+    Ok(serde_json::to_string(&eql_payload).unwrap())
 }
 
 fn encrypt_bulk(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -194,10 +265,10 @@ async fn encrypt_bulk_inner(
 
     let mut source_encrypted = pipeline.encrypt(service_token).await?;
 
-    let mut results: Vec<String> = Vec::with_capacity(len);
+    // let results: Vec<String> = Vec::with_capacity(len);
 
     for i in 0..len {
-        let encrypted = source_encrypted.remove(i).ok_or_else(|| {
+        let _encrypted = source_encrypted.remove(i).ok_or_else(|| {
             Error::InvariantViolation(
                 format!(
                     "`encrypt_bulk` expected a result in the pipeline at index {i}, but there were none"
@@ -205,10 +276,11 @@ async fn encrypt_bulk_inner(
             )
         })?;
 
-        results.push(mp_base85_str_from_encrypted(encrypted)?);
+        // results.push(mp_base85_str_from_encrypted(encrypted)?);
     }
 
-    Ok(results)
+    todo!("implement bulk encryption")
+    // Ok(results)
 }
 
 fn decrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -434,18 +506,102 @@ fn plaintext_str_from_bytes(bytes: Vec<u8>) -> Result<String, Error> {
     }
 }
 
-fn mp_base85_str_from_encrypted(encrypted: Encrypted) -> Result<String, Error> {
-    match encrypted {
-        Encrypted::Record(ciphertext, _terms) => ciphertext
-            .to_mp_base85()
-            // The error type from `to_mp_base85` isn't public, so we don't derive an error for this one.
-            // Instead, we use `map_err`.
-            .map_err(|err| Error::Base85(err.to_string())),
+// fn mp_base85_str_from_encrypted(encrypted: Encrypted) -> Result<String, Error> {
+//     match encrypted {
+//         Encrypted::Record(ciphertext, _terms) => ciphertext
+//             .to_mp_base85()
+//             // The error type from `to_mp_base85` isn't public, so we don't derive an error for this one.
+//             // Instead, we use `map_err`.
+//             .map_err(|err| Error::Base85(err.to_string())),
 
-        Encrypted::SteVec(_) => Err(Error::Unimplemented(
-            "`SteVec`s and encrypted JSONB columns".to_string(),
-        ))?,
+//         Encrypted::SteVec(_) => Err(Error::Unimplemented(
+//             "`SteVec`s and encrypted JSONB columns".to_string(),
+//         ))?,
+//     }
+// }
+
+fn to_eql_encrypted(
+    encrypted: encryption::Encrypted,
+    identifier: &Identifier,
+) -> Result<Encrypted, Error> {
+    match encrypted {
+        encryption::Encrypted::Record(ciphertext, terms) => {
+            // debug!(target: ENCRYPT, ciphertext = ?ciphertext);
+            // debug!(target: ENCRYPT, terms = ?terms);
+
+            struct Indexes {
+                match_index: Option<Vec<u16>>,
+                ore_index: Option<Vec<String>>,
+                unique_index: Option<String>,
+            }
+
+            let mut indexes = Indexes {
+                match_index: None,
+                ore_index: None,
+                unique_index: None,
+            };
+
+            for index_term in terms {
+                match index_term {
+                    IndexTerm::Binary(bytes) => {
+                        indexes.unique_index = Some(format_index_term_binary(&bytes))
+                    }
+                    IndexTerm::BitMap(inner) => indexes.match_index = Some(inner),
+                    IndexTerm::OreArray(vec_of_bytes) => {
+                        indexes.ore_index = Some(format_index_term_ore_array(&vec_of_bytes));
+                    }
+                    IndexTerm::OreFull(bytes) => {
+                        indexes.ore_index = Some(format_index_term_ore(&bytes));
+                    }
+                    IndexTerm::OreLeft(bytes) => {
+                        indexes.ore_index = Some(format_index_term_ore(&bytes));
+                    }
+                    IndexTerm::Null => {}
+                    // _ => return Err(EncryptError::UnknownIndexTerm(identifier.to_owned()).into()),
+                    _ => todo!("unhandled index terms"),
+                };
+            }
+
+            Ok(Encrypted::Ciphertext {
+                ciphertext,
+                identifier: identifier.to_owned(),
+                match_index: indexes.match_index,
+                ore_index: indexes.ore_index,
+                unique_index: indexes.unique_index,
+                version: 1,
+            })
+        }
+        encryption::Encrypted::SteVec(ste_vec_index) => Ok(Encrypted::SteVec {
+            identifier: identifier.to_owned(),
+            ste_vec_index,
+            version: 1,
+        }),
     }
+}
+
+fn format_index_term_binary(bytes: &Vec<u8>) -> String {
+    hex::encode(bytes)
+}
+
+fn format_index_term_ore_bytea(bytes: &Vec<u8>) -> String {
+    hex::encode(bytes)
+}
+
+///
+/// Formats a Vec<Vec<u8>> into a Vec<String>
+///
+fn format_index_term_ore_array(vec_of_bytes: &[Vec<u8>]) -> Vec<String> {
+    vec_of_bytes
+        .iter()
+        .map(format_index_term_ore_bytea)
+        .collect()
+}
+
+///
+/// Formats a Vec<Vec<u8>> into a single elenent Vec<String>
+///
+fn format_index_term_ore(bytes: &Vec<u8>) -> Vec<String> {
+    vec![format_index_term_ore_bytea(bytes)]
 }
 
 #[neon::main]

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -516,29 +516,12 @@ fn plaintext_str_from_bytes(bytes: Vec<u8>) -> Result<String, Error> {
     }
 }
 
-// fn mp_base85_str_from_encrypted(encrypted: Encrypted) -> Result<String, Error> {
-//     match encrypted {
-//         Encrypted::Record(ciphertext, _terms) => ciphertext
-//             .to_mp_base85()
-//             // The error type from `to_mp_base85` isn't public, so we don't derive an error for this one.
-//             // Instead, we use `map_err`.
-//             .map_err(|err| Error::Base85(err.to_string())),
-
-//         Encrypted::SteVec(_) => Err(Error::Unimplemented(
-//             "`SteVec`s and encrypted JSONB columns".to_string(),
-//         ))?,
-//     }
-// }
-
 fn to_eql_encrypted(
     encrypted: encryption::Encrypted,
     identifier: &Identifier,
 ) -> Result<Encrypted, Error> {
     match encrypted {
         encryption::Encrypted::Record(ciphertext, terms) => {
-            // debug!(target: ENCRYPT, ciphertext = ?ciphertext);
-            // debug!(target: ENCRYPT, terms = ?terms);
-
             struct Indexes {
                 match_index: Option<Vec<u16>>,
                 ore_index: Option<Vec<String>>,

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -140,12 +140,10 @@ async fn new_client_inner(encrypt_config: EncryptConfig) -> Result<Client, Error
 fn encrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
     let client = (**cx.argument::<JsBox<Client>>(0)?).clone();
     let plaintext = cx.argument::<JsString>(1)?.value(&mut cx);
-    // TODO: consider making column config an arg instead.
     let column_name = cx.argument::<JsString>(2)?.value(&mut cx);
     let table_name = cx.argument::<JsString>(3)?.value(&mut cx);
-
-    let lock_context = encryption_context_from_js_value(cx.argument_opt(5), &mut cx)?;
-    let service_token = service_token_from_js_value(cx.argument_opt(6), &mut cx)?;
+    let lock_context = encryption_context_from_js_value(cx.argument_opt(4), &mut cx)?;
+    let service_token = service_token_from_js_value(cx.argument_opt(5), &mut cx)?;
 
     let rt = runtime(&mut cx)?;
     let channel = cx.channel();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.12.0-3",
+      "version": "0.12.0-4",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.12.0-2",
+      "version": "0.12.0-3",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.12.0-0",
+      "version": "0.12.0-1",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.11.0",
+      "version": "0.12.0-0",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.12.0-1",
+      "version": "0.12.0-2",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "os": [
     "darwin"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "os": [
     "linux"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "os": [
     "linux"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "os": [
     "linux"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "os": [
     "linux"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.12.0-0",
+  "version": "0.12.0-1",
   "os": [
     "win32"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.12.0-2",
+  "version": "0.12.0-3",
   "os": [
     "win32"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.11.0",
+  "version": "0.12.0-0",
   "os": [
     "win32"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.12.0-1",
+  "version": "0.12.0-2",
   "os": [
     "win32"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.12.0-3",
+  "version": "0.12.0-4",
   "os": [
     "win32"
   ],

--- a/src/index.cts
+++ b/src/index.cts
@@ -8,7 +8,7 @@ import * as addon from './load.cjs'
 declare module './load.cjs' {
   interface Client {}
 
-  function newClient(): Promise<Client>
+  function newClient(encryptSchema?: string): Promise<Client>
   function encrypt(
     client: Client,
     plaintext: string,
@@ -34,8 +34,8 @@ declare module './load.cjs' {
   ): Promise<string[]>
 }
 
-export function newClient(): Promise<addon.Client> {
-  return addon.newClient()
+export function newClient(encryptSchema?: string): Promise<addon.Client> {
+  return addon.newClient(encryptSchema)
 }
 
 export function encrypt(

--- a/src/index.cts
+++ b/src/index.cts
@@ -13,6 +13,7 @@ declare module './load.cjs' {
     client: Client,
     plaintext: string,
     columnName: string,
+    tableName?: string,
     context?: Context,
     ctsToken?: CtsToken,
   ): Promise<string>
@@ -42,18 +43,26 @@ export function encrypt(
   client: addon.Client,
   plaintext: string,
   columnName: string,
+  tableName?: string,
   lockContext?: Context,
   ctsToken?: CtsToken,
 ): Promise<string> {
   if (ctsToken) {
-    return addon.encrypt(client, plaintext, columnName, lockContext, ctsToken)
+    return addon.encrypt(
+      client,
+      plaintext,
+      columnName,
+      tableName,
+      lockContext,
+      ctsToken,
+    )
   }
 
   if (lockContext) {
-    return addon.encrypt(client, plaintext, columnName, lockContext)
+    return addon.encrypt(client, plaintext, columnName, tableName, lockContext)
   }
 
-  return addon.encrypt(client, plaintext, columnName)
+  return addon.encrypt(client, plaintext, columnName, tableName)
 }
 
 export function decrypt(
@@ -100,6 +109,7 @@ export function decryptBulk(
 export type BulkEncryptPayload = {
   plaintext: string
   column: string
+  table?: string
   lockContext?: Context
 }
 


### PR DESCRIPTION
This change adds in support for Encrypt config and indexing for search.

Changes:
- `newClient` now accepts an Encrypt config as an arg.
- `encrypt`/`encryptBulk` now need to be passed a table name. The table name and column name are used to look up the column config from the Encrypt config.
- `encrypt`/`encryptBulk` now return the full encrypted EQL payload instead of only the source ciphertext.

I've added a few PR comments on some improvements to consider in follow-up changes, but I think that this PR is in a mergable/releasable state.