### PR TITLE
Refactor `encrypt` interface and various TS types

### DIFF
--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -9,7 +9,7 @@ use cipherstash_client::{
         ScopedCipher, SteVec, TypeParseError,
     },
     schema::ColumnConfig,
-    zerokms::{self, encrypted_record, EncryptedRecord, WithContext, ZeroKMSWithClientKey},
+    zerokms::{self, EncryptedRecord, WithContext, ZeroKMSWithClientKey},
 };
 use encrypt_config::{EncryptConfig, Identifier};
 use neon::prelude::*;
@@ -43,8 +43,8 @@ impl Finalize for Client {}
 pub enum Encrypted {
     #[serde(rename = "ct")]
     Ciphertext {
-        #[serde(rename = "c", with = "encrypted_record::formats::mp_base85")]
-        ciphertext: EncryptedRecord,
+        #[serde(rename = "c")]
+        ciphertext: String,
         #[serde(rename = "o")]
         ore_index: Option<Vec<String>>,
         #[serde(rename = "m")]
@@ -170,8 +170,7 @@ fn encrypt(mut cx: FunctionContext) -> JsResult<JsPromise> {
         // should be performed outside of it.
         deferred.settle_with(&channel, move |mut cx| {
             let ciphertext = ciphertext_result.or_else(|err| cx.throw_error(err.to_string()))?;
-
-            Ok(cx.string(ciphertext))
+            eql_encrypted_to_js(ciphertext, &mut cx)
         });
     });
 
@@ -183,7 +182,7 @@ async fn encrypt_inner(
     plaintext_target: PlaintextTarget,
     ident: Identifier,
     service_token: Option<ServiceToken>,
-) -> Result<String, Error> {
+) -> Result<Encrypted, Error> {
     let mut pipeline = ReferencedPendingPipeline::new(client.cipher);
 
     pipeline.add_with_ref::<PlaintextTarget>(plaintext_target, 0)?;
@@ -196,9 +195,7 @@ async fn encrypt_inner(
         )
     })?;
 
-    let eql_payload = to_eql_encrypted(encrypted, &ident)?;
-
-    eql_encrypted_to_json_string(&eql_payload)
+    to_eql_encrypted(encrypted, &ident)
 }
 
 fn encrypt_bulk(mut cx: FunctionContext) -> JsResult<JsPromise> {
@@ -220,7 +217,7 @@ fn encrypt_bulk(mut cx: FunctionContext) -> JsResult<JsPromise> {
 
         deferred.settle_with(&channel, move |mut cx| {
             let ciphertexts = ciphertexts_result.or_else(|err| cx.throw_error(err.to_string()))?;
-            js_array_from_string_vec(ciphertexts, &mut cx)
+            js_array_from_eql_encrypted_vec(ciphertexts, &mut cx)
         });
     });
 
@@ -231,7 +228,7 @@ async fn encrypt_bulk_inner(
     client: Client,
     plaintext_targets: Vec<(PlaintextTarget, Identifier)>,
     service_token: Option<ServiceToken>,
-) -> Result<Vec<String>, Error> {
+) -> Result<Vec<Encrypted>, Error> {
     let len = plaintext_targets.len();
     let mut pipeline = ReferencedPendingPipeline::new(client.cipher);
     let (plaintext_targets, identifiers): (Vec<PlaintextTarget>, Vec<Identifier>) =
@@ -243,7 +240,7 @@ async fn encrypt_bulk_inner(
 
     let mut source_encrypted = pipeline.encrypt(service_token).await?;
 
-    let mut results: Vec<String> = Vec::with_capacity(len);
+    let mut results: Vec<Encrypted> = Vec::with_capacity(len);
 
     for i in 0..len {
         let encrypted = source_encrypted.remove(i).ok_or_else(|| {
@@ -260,7 +257,7 @@ async fn encrypt_bulk_inner(
 
         let eql_payload = to_eql_encrypted(encrypted, ident)?;
 
-        results.push(eql_encrypted_to_json_string(&eql_payload)?);
+        results.push(eql_payload);
     }
 
     Ok(results)
@@ -482,6 +479,34 @@ fn js_array_from_string_vec<'a, C: Context<'a>>(
     Ok(js_array)
 }
 
+fn js_array_from_u16_vec<'a, C: Context<'a>>(
+    vec: Vec<u16>,
+    cx: &mut C,
+) -> NeonResult<Handle<'a, JsArray>> {
+    let js_array = JsArray::new(cx, vec.len());
+
+    for (i, value) in vec.iter().enumerate() {
+        let js_number = cx.number(*value);
+        js_array.set(cx, i as u32, js_number)?;
+    }
+
+    Ok(js_array)
+}
+
+fn js_array_from_eql_encrypted_vec<'a, C: Context<'a>>(
+    vec: Vec<Encrypted>,
+    cx: &mut C,
+) -> NeonResult<Handle<'a, JsArray>> {
+    let js_array = JsArray::new(cx, vec.len());
+
+    for (i, value) in vec.into_iter().enumerate() {
+        let js_obj = eql_encrypted_to_js(value, cx)?;
+        js_array.set(cx, i as u32, js_obj)?;
+    }
+
+    Ok(js_array)
+}
+
 fn encrypted_record_from_mp_base85(
     base85str: &str,
     encryption_context: Vec<zerokms::Context>,
@@ -546,6 +571,12 @@ fn to_eql_encrypted(
                 };
             }
 
+            let ciphertext = ciphertext
+                .to_mp_base85()
+                // The error type from `to_mp_base85` isn't public, so we don't derive an error for this one.
+                // Instead, we use `map_err`.
+                .map_err(|err| Error::Base85(err.to_string()))?;
+
             Ok(Encrypted::Ciphertext {
                 ciphertext,
                 identifier: identifier.to_owned(),
@@ -561,6 +592,71 @@ fn to_eql_encrypted(
             version: 1,
         }),
     }
+}
+
+fn eql_encrypted_to_js<'cx, C: Context<'cx>>(
+    encrypted: Encrypted,
+    cx: &mut C,
+) -> NeonResult<Handle<'cx, JsObject>> {
+    let obj: Handle<JsObject> = cx.empty_object();
+
+    let Encrypted::Ciphertext {
+        ciphertext,
+        ore_index,
+        match_index,
+        unique_index,
+        identifier,
+        version,
+    } = encrypted
+    else {
+        return cx
+            .throw_error(Error::Unimplemented("encrypted JSON columns".to_string()).to_string());
+    };
+
+    let k = cx.string("ct");
+    obj.set(cx, "k", k)?;
+
+    let c = cx.string(ciphertext);
+    obj.set(cx, "c", c)?;
+
+    if let Some(ore_index) = ore_index {
+        let o = js_array_from_string_vec(ore_index, cx)?;
+        obj.set(cx, "o", o)?;
+    } else {
+        let o = cx.null();
+        obj.set(cx, "o", o)?;
+    }
+
+    if let Some(match_index) = match_index {
+        let m = js_array_from_u16_vec(match_index, cx)?;
+        obj.set(cx, "m", m)?;
+    } else {
+        let m = cx.null();
+        obj.set(cx, "m", m)?;
+    }
+
+    if let Some(unique_index) = unique_index {
+        let u = cx.string(unique_index);
+        obj.set(cx, "u", u)?;
+    } else {
+        let u = cx.null();
+        obj.set(cx, "u", u)?;
+    }
+
+    let i = cx.empty_object();
+
+    let col = cx.string(identifier.column);
+    i.set(cx, "c", col)?;
+
+    let t = cx.string(identifier.table);
+    i.set(cx, "t", t)?;
+
+    obj.set(cx, "i", i)?;
+
+    let v = cx.number(version);
+    obj.set(cx, "v", v)?;
+
+    Ok(obj)
 }
 
 fn format_index_term_binary(bytes: &Vec<u8>) -> String {
@@ -586,15 +682,6 @@ fn format_index_term_ore_array(vec_of_bytes: &[Vec<u8>]) -> Vec<String> {
 ///
 fn format_index_term_ore(bytes: &Vec<u8>) -> Vec<String> {
     vec![format_index_term_ore_bytea(bytes)]
-}
-
-fn eql_encrypted_to_json_string(encrypted: &Encrypted) -> Result<String, Error> {
-    serde_json::to_string(encrypted).map_err(|_| {
-        Error::InvariantViolation(
-            "expected EQL payload to be serialiable as JSON, but it could not be serialized"
-                .to_string(),
-        )
-    })
 }
 
 fn is_defined(js_value: Handle<'_, JsValue>, cx: &mut FunctionContext) -> bool {

--- a/integration-tests/tests/index.test.ts
+++ b/integration-tests/tests/index.test.ts
@@ -3,7 +3,41 @@ import { expect, test } from 'vitest'
 import { decrypt, encrypt, newClient } from '@cipherstash/protect-ffi'
 
 test('can round-trip encrypt and decrypt', async () => {
-  const encryptConfig = {
+  const client = await newClient(encryptConfig())
+  const originalPlaintext = 'abc'
+
+  const ciphertext = await encrypt(client, {
+    plaintext: originalPlaintext,
+    column: 'email',
+    table: 'users',
+  })
+
+  const decrypted = await decrypt(client, JSON.parse(ciphertext).c)
+
+  expect(decrypted).toBe(originalPlaintext)
+})
+
+test('can pass in undefined for ctsToken', async () => {
+  const client = await newClient(encryptConfig())
+  const originalPlaintext = 'abc'
+
+  const ciphertext = await encrypt(
+    client,
+    {
+      plaintext: originalPlaintext,
+      column: 'email',
+      table: 'users',
+    },
+    undefined,
+  )
+
+  const decrypted = await decrypt(client, JSON.parse(ciphertext).c, undefined)
+
+  expect(decrypted).toBe(originalPlaintext)
+})
+
+function encryptConfig() {
+  return JSON.stringify({
     v: 1,
     tables: {
       users: {
@@ -16,13 +50,5 @@ test('can round-trip encrypt and decrypt', async () => {
         },
       },
     },
-  }
-
-  const client = await newClient(JSON.stringify(encryptConfig))
-
-  const ciphertext = await encrypt(client, 'abc', 'email', 'users')
-
-  const plaintext = await decrypt(client, JSON.parse(ciphertext).c)
-
-  expect(plaintext).toBe('abc')
-})
+  })
+}

--- a/integration-tests/tests/index.test.ts
+++ b/integration-tests/tests/index.test.ts
@@ -19,7 +19,7 @@ describe('encrypt and decrypt', async () => {
       table: 'users',
     })
 
-    const decrypted = await decrypt(client, JSON.parse(ciphertext).c)
+    const decrypted = await decrypt(client, ciphertext.c)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -38,7 +38,7 @@ describe('encrypt and decrypt', async () => {
       undefined,
     )
 
-    const decrypted = await decrypt(client, JSON.parse(ciphertext).c, undefined)
+    const decrypted = await decrypt(client, ciphertext.c, undefined)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -65,7 +65,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map((ct) => ({ ciphertext: JSON.parse(ct).c })),
+      ciphertexts.map(({ c }) => ({ ciphertext: c })),
     )
 
     expect(decrypted).toEqual([plaintextOne, plaintextTwo])
@@ -95,7 +95,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map((ct) => ({ ciphertext: JSON.parse(ct).c })),
+      ciphertexts.map(({ c }) => ({ ciphertext: c })),
       undefined,
     )
 

--- a/integration-tests/tests/index.test.ts
+++ b/integration-tests/tests/index.test.ts
@@ -1,39 +1,106 @@
-import { expect, test } from 'vitest'
+import { describe, expect, test } from 'vitest'
 
-import { decrypt, encrypt, newClient } from '@cipherstash/protect-ffi'
+import {
+  decrypt,
+  decryptBulk,
+  encrypt,
+  encryptBulk,
+  newClient,
+} from '@cipherstash/protect-ffi'
 
-test('can round-trip encrypt and decrypt', async () => {
-  const client = await newClient(encryptConfig())
-  const originalPlaintext = 'abc'
+describe('encrypt and decrypt', async () => {
+  test('can round-trip encrypt and decrypt', async () => {
+    const client = await newClient(encryptConfig())
+    const originalPlaintext = 'abc'
 
-  const ciphertext = await encrypt(client, {
-    plaintext: originalPlaintext,
-    column: 'email',
-    table: 'users',
-  })
-
-  const decrypted = await decrypt(client, JSON.parse(ciphertext).c)
-
-  expect(decrypted).toBe(originalPlaintext)
-})
-
-test('can pass in undefined for ctsToken', async () => {
-  const client = await newClient(encryptConfig())
-  const originalPlaintext = 'abc'
-
-  const ciphertext = await encrypt(
-    client,
-    {
+    const ciphertext = await encrypt(client, {
       plaintext: originalPlaintext,
       column: 'email',
       table: 'users',
-    },
-    undefined,
-  )
+    })
 
-  const decrypted = await decrypt(client, JSON.parse(ciphertext).c, undefined)
+    const decrypted = await decrypt(client, JSON.parse(ciphertext).c)
 
-  expect(decrypted).toBe(originalPlaintext)
+    expect(decrypted).toBe(originalPlaintext)
+  })
+
+  test('can pass in undefined for ctsToken', async () => {
+    const client = await newClient(encryptConfig())
+    const originalPlaintext = 'abc'
+
+    const ciphertext = await encrypt(
+      client,
+      {
+        plaintext: originalPlaintext,
+        column: 'email',
+        table: 'users',
+      },
+      undefined,
+    )
+
+    const decrypted = await decrypt(client, JSON.parse(ciphertext).c, undefined)
+
+    expect(decrypted).toBe(originalPlaintext)
+  })
+})
+
+describe('encryptBulk and decryptBulk', async () => {
+  test('can round-trip encrypt and decrypt', async () => {
+    const client = await newClient(encryptConfig())
+    const plaintextOne = 'abc'
+    const plaintextTwo = 'def'
+
+    const ciphertexts = await encryptBulk(client, [
+      {
+        plaintext: plaintextOne,
+        column: 'email',
+        table: 'users',
+      },
+      {
+        plaintext: plaintextTwo,
+        column: 'email',
+        table: 'users',
+      },
+    ])
+
+    const decrypted = await decryptBulk(
+      client,
+      ciphertexts.map((ct) => ({ ciphertext: JSON.parse(ct).c })),
+    )
+
+    expect(decrypted).toEqual([plaintextOne, plaintextTwo])
+  })
+
+  test('can pass in undefined for ctsToken', async () => {
+    const client = await newClient(encryptConfig())
+    const plaintextOne = 'abc'
+    const plaintextTwo = 'def'
+
+    const ciphertexts = await encryptBulk(
+      client,
+      [
+        {
+          plaintext: plaintextOne,
+          column: 'email',
+          table: 'users',
+        },
+        {
+          plaintext: plaintextTwo,
+          column: 'email',
+          table: 'users',
+        },
+      ],
+      undefined,
+    )
+
+    const decrypted = await decryptBulk(
+      client,
+      ciphertexts.map((ct) => ({ ciphertext: JSON.parse(ct).c })),
+      undefined,
+    )
+
+    expect(decrypted).toEqual([plaintextOne, plaintextTwo])
+  })
 })
 
 function encryptConfig() {

--- a/integration-tests/tests/postgres.test.ts
+++ b/integration-tests/tests/postgres.test.ts
@@ -42,12 +42,11 @@ describe('postgres', async () => {
   test('can round-trip encrypt and decrypt', async () => {
     const originalPlaintext = 'abc'
 
-    const ciphertext = await encrypt(
-      protectClient,
-      originalPlaintext,
-      'email',
-      'users',
-    )
+    const ciphertext = await encrypt(protectClient, {
+      plaintext: originalPlaintext,
+      column: 'email',
+      table: 'users',
+    })
 
     await pg.query('INSERT INTO encrypted (encrypted_text) VALUES ($1)', [
       ciphertext,
@@ -123,7 +122,13 @@ describe('postgres', async () => {
       SELECT encrypted_text FROM encrypted
       WHERE cs_match_v1(encrypted_text) @> cs_match_v1($1)
       `,
-      [await encrypt(protectClient, 'ccc', 'email', 'users')],
+      [
+        await encrypt(protectClient, {
+          plaintext: 'ccc',
+          column: 'email',
+          table: 'users',
+        }),
+      ],
     )
 
     const decrypted = await decryptBulk(
@@ -158,7 +163,13 @@ describe('postgres', async () => {
       SELECT encrypted_text FROM encrypted
       WHERE cs_unique_v1(encrypted_text) = cs_unique_v1($1)
       `,
-      [await encrypt(protectClient, 'b', 'email', 'users')],
+      [
+        await encrypt(protectClient, {
+          plaintext: 'b',
+          column: 'email',
+          table: 'users',
+        }),
+      ],
     )
 
     const decrypted = await decryptBulk(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.12.0",
+      "version": "0.13.0-0",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.13.0-0",
+      "version": "0.13.0-1",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "os": [
     "darwin"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "os": [
     "linux"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "os": [
     "linux"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.13.0-0",
+  "version": "0.13.0-1",
   "os": [
     "win32"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.12.0",
+  "version": "0.13.0-0",
   "os": [
     "win32"
   ],

--- a/src/index.cts
+++ b/src/index.cts
@@ -3,11 +3,14 @@
 // The Rust addon.
 import * as addon from './load.cjs'
 
+declare const sym: unique symbol
+
+// Poor man's opaque type.
+export type Client = { readonly [sym]: unknown }
+
 // Use this declaration to assign types to the jseql's exports,
 // which otherwise by default are `any`.
 declare module './load.cjs' {
-  interface Client {}
-
   function newClient(encryptSchema?: string): Promise<Client>
   function encrypt(
     client: Client,
@@ -32,14 +35,14 @@ declare module './load.cjs' {
   ): Promise<string[]>
 }
 
-export function newClient(encryptSchema?: string): Promise<addon.Client> {
+export function newClient(encryptSchema?: string): Promise<Client> {
   return addon.newClient(encryptSchema)
 }
 
 export const encrypt = addon.encrypt
 
 export function decrypt(
-  client: addon.Client,
+  client: Client,
   ciphertext: string,
   lockContext?: Context,
   ctsToken?: CtsToken,
@@ -56,7 +59,7 @@ export function decrypt(
 }
 
 export function encryptBulk(
-  client: addon.Client,
+  client: Client,
   plaintextTargets: EncryptPayload[],
   ctsToken?: CtsToken,
 ): Promise<string[]> {
@@ -68,7 +71,7 @@ export function encryptBulk(
 }
 
 export function decryptBulk(
-  client: addon.Client,
+  client: Client,
   ciphertexts: BulkDecryptPayload[],
   ctsToken?: CtsToken,
 ): Promise<string[]> {

--- a/src/index.cts
+++ b/src/index.cts
@@ -11,10 +11,7 @@ declare module './load.cjs' {
   function newClient(encryptSchema?: string): Promise<Client>
   function encrypt(
     client: Client,
-    plaintext: string,
-    columnName: string,
-    tableName?: string,
-    context?: Context,
+    plaintext: EncryptPayload,
     ctsToken?: CtsToken,
   ): Promise<string>
   function decrypt(
@@ -25,7 +22,7 @@ declare module './load.cjs' {
   ): Promise<string>
   function encryptBulk(
     client: Client,
-    plaintextTargets: BulkEncryptPayload[],
+    plaintextTargets: EncryptPayload[],
     ctsToken?: CtsToken,
   ): Promise<string[]>
   function decryptBulk(
@@ -39,31 +36,7 @@ export function newClient(encryptSchema?: string): Promise<addon.Client> {
   return addon.newClient(encryptSchema)
 }
 
-export function encrypt(
-  client: addon.Client,
-  plaintext: string,
-  columnName: string,
-  tableName?: string,
-  lockContext?: Context,
-  ctsToken?: CtsToken,
-): Promise<string> {
-  if (ctsToken) {
-    return addon.encrypt(
-      client,
-      plaintext,
-      columnName,
-      tableName,
-      lockContext,
-      ctsToken,
-    )
-  }
-
-  if (lockContext) {
-    return addon.encrypt(client, plaintext, columnName, tableName, lockContext)
-  }
-
-  return addon.encrypt(client, plaintext, columnName, tableName)
-}
+export const encrypt = addon.encrypt
 
 export function decrypt(
   client: addon.Client,
@@ -84,7 +57,7 @@ export function decrypt(
 
 export function encryptBulk(
   client: addon.Client,
-  plaintextTargets: BulkEncryptPayload[],
+  plaintextTargets: EncryptPayload[],
   ctsToken?: CtsToken,
 ): Promise<string[]> {
   if (ctsToken) {
@@ -106,10 +79,10 @@ export function decryptBulk(
   return addon.decryptBulk(client, ciphertexts)
 }
 
-export type BulkEncryptPayload = {
+export type EncryptPayload = {
   plaintext: string
   column: string
-  table?: string
+  table: string
   lockContext?: Context
 }
 

--- a/src/index.cts
+++ b/src/index.cts
@@ -8,10 +8,10 @@ declare const sym: unique symbol
 // Poor man's opaque type.
 export type Client = { readonly [sym]: unknown }
 
-// Use this declaration to assign types to the jseql's exports,
-// which otherwise by default are `any`.
+// Use this declaration to assign types to the protect-ffi's exports,
+// which otherwise default to `any`.
 declare module './load.cjs' {
-  function newClient(encryptSchema?: string): Promise<Client>
+  function newClient(encryptSchema: string): Promise<Client>
   function encrypt(
     client: Client,
     plaintext: EncryptPayload,

--- a/src/index.cts
+++ b/src/index.cts
@@ -72,12 +72,3 @@ export type CtsToken = {
 export type Context = {
   identityClaim: string[]
 }
-
-export type EncryptedEqlPayload = {
-  c: string
-}
-
-export type BulkEncryptedEqlPayload = {
-  c: string
-  id: string
-}[]

--- a/src/index.cts
+++ b/src/index.cts
@@ -1,7 +1,7 @@
 // This module is the CJS entry point for the library.
 
-// The Rust addon.
-import * as addon from './load.cjs'
+export { encrypt, encryptBulk, newClient, decryptBulk } from './load.cjs'
+import { decrypt as ffiDecrypt } from './load.cjs'
 
 declare const sym: unique symbol
 
@@ -35,12 +35,6 @@ declare module './load.cjs' {
   ): Promise<string[]>
 }
 
-export function newClient(encryptSchema?: string): Promise<Client> {
-  return addon.newClient(encryptSchema)
-}
-
-export const encrypt = addon.encrypt
-
 export function decrypt(
   client: Client,
   ciphertext: string,
@@ -48,38 +42,14 @@ export function decrypt(
   ctsToken?: CtsToken,
 ): Promise<string> {
   if (ctsToken) {
-    return addon.decrypt(client, ciphertext, lockContext, ctsToken)
+    return ffiDecrypt(client, ciphertext, lockContext, ctsToken)
   }
 
   if (lockContext) {
-    return addon.decrypt(client, ciphertext, lockContext)
+    return ffiDecrypt(client, ciphertext, lockContext)
   }
 
-  return addon.decrypt(client, ciphertext)
-}
-
-export function encryptBulk(
-  client: Client,
-  plaintextTargets: EncryptPayload[],
-  ctsToken?: CtsToken,
-): Promise<string[]> {
-  if (ctsToken) {
-    return addon.encryptBulk(client, plaintextTargets, ctsToken)
-  }
-
-  return addon.encryptBulk(client, plaintextTargets)
-}
-
-export function decryptBulk(
-  client: Client,
-  ciphertexts: BulkDecryptPayload[],
-  ctsToken?: CtsToken,
-): Promise<string[]> {
-  if (ctsToken) {
-    return addon.decryptBulk(client, ciphertexts, ctsToken)
-  }
-
-  return addon.decryptBulk(client, ciphertexts)
+  return ffiDecrypt(client, ciphertext)
 }
 
 export type EncryptPayload = {

--- a/src/index.cts
+++ b/src/index.cts
@@ -16,7 +16,7 @@ declare module './load.cjs' {
     client: Client,
     plaintext: EncryptPayload,
     ctsToken?: CtsToken,
-  ): Promise<string>
+  ): Promise<Encrypted>
   function decrypt(
     client: Client,
     ciphertext: string,
@@ -27,7 +27,7 @@ declare module './load.cjs' {
     client: Client,
     plaintextTargets: EncryptPayload[],
     ctsToken?: CtsToken,
-  ): Promise<string[]>
+  ): Promise<Encrypted[]>
   function decryptBulk(
     client: Client,
     ciphertexts: BulkDecryptPayload[],
@@ -71,4 +71,17 @@ export type CtsToken = {
 
 export type Context = {
   identityClaim: string[]
+}
+
+export type Encrypted = {
+  k: string
+  c: string
+  o: string[] | null
+  m: number[] | null
+  u: string | null
+  i: {
+    c: string
+    t: string
+  }
+  v: number
 }


### PR DESCRIPTION
Changes:
- Combine `plaintext`, `columnName`, `tableName`, and `lockContext` args into a single opts object for `encrypt`
  - The opts type, `EncryptPayload`, is shared between `encrypt` and `encryptBulk`
- Return JS objects from `encrypt`/`encryptBulk` instead of strings
- Make `encryptSchema` arg for `newClient` required
  - This was already the behaviour on the Rust side, but now the types match the behaviour
- Make the `table` property passed to `encrypt` and `encryptBulk` required
  - This was already the behaviour on the Rust side, but now the types match the behaviour
- Remove unused `EncryptedEqlPayload` and `BulkEncryptedEqlPayload` types
- Push logic for handling `undefined` `cstToken`s from TS to Rust
- Add integration tests for `encryptBulk` and `decryptBulk`
- Add integration tests for passing in `undefined` for `ctsToken`