### PR TITLE
Chore: add Postgres integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,16 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    env:
+      CS_WORKSPACE_ID: ${{ secrets.CS_WORKSPACE_ID }}
+      CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
+      CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
+      CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
+      PGPORT: 5432
+      PGDATABASE: cipherstash
+      PGUSER: cipherstash
+      PGPASSWORD: password
+      PGHOST: localhost
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -69,11 +79,12 @@ jobs:
       - name: Install integration test dependencies
         run: npm ci
         working-directory: ./integration-tests
+      - name: Set up integration test DB
+        run: |
+          docker compose up --detach --wait
+          npm run eql:download
+          npm run eql:install
+        working-directory: ./integration-tests
       - name: Test (integration)
-        env:
-          CS_WORKSPACE_ID: ${{ secrets.CS_WORKSPACE_ID }}
-          CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
-          CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
-          CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
         run: npm test
         working-directory: ./integration-tests

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cargo.log
 cross.log
 mise.local.toml
 cipherstash.secret.toml
+cipherstash-*.sql

--- a/README.md
+++ b/README.md
@@ -124,7 +124,10 @@ protect-ffi/
 Integration tests live in the `./integration-tests` directory.
 These tests use the local build of Rust and JavaScript artifacts to test `@cipherstash/protect-ffi` as API consumers would.
 
-These tests rely on CipherStash to be configured (via `.toml` config or environment variables) and for environment variables for Postgres to be set.
+These tests rely on:
+
+- CipherStash to be configured (via `.toml` config or environment variables), and 
+- Environment variables for Postgres to be set
 
 Example environment variables:
 ```

--- a/README.md
+++ b/README.md
@@ -124,20 +124,28 @@ protect-ffi/
 Integration tests live in the `./integration-tests` directory.
 These tests use the local build of Rust and JavaScript artifacts to test `@cipherstash/protect-ffi` as API consumers would.
 
-These tests rely on CipherStash to be configured (via `.toml` config or environment variables).
+These tests rely on CipherStash to be configured (via `.toml` config or environment variables) and for environment variables for Postgres to be set.
 
-Example environment variables to set:
+Example environment variables:
 ```
 CS_CLIENT_ID=
 CS_CLIENT_KEY=
 CS_CLIENT_ACCESS_KEY=
 CS_WORKSPACE_ID=
+PGPORT=5432
+PGDATABASE=cipherstash
+PGUSER=cipherstash
+PGPASSWORD=password
+PGHOST=localhost
 ```
 
 To run integration tests:
 ```
 npm run debug
 cd integration-tests
+docker compose up --detach --wait
+npm run eql:download
+npm run eql:install
 npm run test
 ```
 

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:latest
     container_name: protect-ffi-postgres
     environment:
-      POSTGRES_DB: cipherstash
-      POSTGRES_USER: cipherstash
-      POSTGRES_PASSWORD: password
+      - POSTGRES_DB=${PGDATABASE:-cipherstash}
+      - POSTGRES_USER=${PGUSER:-cipherstash}
+      - POSTGRES_PASSWORD=${PGPASSWORD:-password}
     ports:
       - 5432:5432
     restart: always

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgres:latest
+    container_name: protect-ffi-postgres
+    environment:
+      POSTGRES_DB: cipherstash
+      POSTGRES_USER: cipherstash
+      POSTGRES_PASSWORD: password
+    ports:
+      - 5432:5432
+    restart: always
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 1s
+      timeout: 5s
+      retries: 10

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cipherstash/protect-ffi": ".."
+        "@cipherstash/protect-ffi": "..",
+        "pg": "^8.13.3"
       },
       "devDependencies": {
+        "@types/pg": "^8.11.11",
         "typescript": "^5.3.3",
         "vitest": "^3.0.7"
       }
@@ -24,6 +26,7 @@
         "@neon-rs/load": "^0.1.82"
       },
       "devDependencies": {
+        "@biomejs/biome": "1.9.4",
         "@neon-rs/cli": "^0.1.82",
         "@tsconfig/node20": "^20.1.4",
         "@types/node": "^20.11.16",
@@ -739,6 +742,90 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.20.0"
+      }
+    },
+    "node_modules/@types/pg": {
+      "version": "8.11.11",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.11.tgz",
+      "integrity": "sha512-kGT1qKM8wJQ5qlawUrEkXgvMSXoV213KfMGXcwfDwUIfUHXqXYXOfS1nE1LINRJVVVx5wCm70XnFlMHaIcQAfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "pg-protocol": "*",
+        "pg-types": "^4.0.1"
+      }
+    },
+    "node_modules/@types/pg/node_modules/pg-types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-4.0.2.tgz",
+      "integrity": "sha512-cRL3JpS3lKMGsKaWndugWQoLOCoP+Cic8oseVcbr0qhPzYD5DWXK+RZ9LY9wxRf7RQia4SCwQlXk0q6FCPrVng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "pg-numeric": "1.0.2",
+        "postgres-array": "~3.0.1",
+        "postgres-bytea": "~3.0.0",
+        "postgres-date": "~2.1.0",
+        "postgres-interval": "^3.0.0",
+        "postgres-range": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-array": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-3.0.4.tgz",
+      "integrity": "sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-bytea": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-3.0.0.tgz",
+      "integrity": "sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obuf": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-date": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-2.1.0.tgz",
+      "integrity": "sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/pg/node_modules/postgres-interval": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-3.0.0.tgz",
+      "integrity": "sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.0.8",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.0.8.tgz",
@@ -1053,6 +1140,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obuf": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+      "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -1068,6 +1162,105 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pg": {
+      "version": "8.13.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.3.tgz",
+      "integrity": "sha512-P6tPt9jXbL9HVu/SSRERNYaYG++MjnscnegFh9pPHihfoBSujsrka0hyuymMzeJKFWrcG8wvCKy8rCe8e5nDUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.7.0",
+        "pg-pool": "^3.7.1",
+        "pg-protocol": "^1.7.1",
+        "pg-types": "^2.1.0",
+        "pgpass": "1.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.1.1"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
+      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.7.0.tgz",
+      "integrity": "sha512-PI2W9mv53rXJQEOb8xNR8lH7Hr+EKa6oJa38zsK0S/ky2er16ios1wLKhZyxzD7jUReiWokc9WK5nxSnC7W1TA==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-numeric": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pg-numeric/-/pg-numeric-1.0.2.tgz",
+      "integrity": "sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.1.tgz",
+      "integrity": "sha512-xIOsFoh7Vdhojas6q3596mXFsR8nwBQBXX5JiV7p9buEVAGqYL4yFzclON5P9vFrpu1u7Zwl2oriyDa89n0wbw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.1.tgz",
+      "integrity": "sha512-gjTHWGYWsEgy9MsY0Gp6ZJxV24IjDqdpTW7Eh0x+WfJLFsm/TJx1MzL6T0D88mBvkpxotCQ6TwW6N+Kko7lhgQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
       }
     },
     "node_modules/picocolors": {
@@ -1105,6 +1298,52 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-range": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/postgres-range/-/postgres-range-1.1.4.tgz",
+      "integrity": "sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.34.9",
@@ -1160,6 +1399,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stackback": {
@@ -1233,6 +1481,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "6.2.0",
@@ -1414,6 +1669,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     }
   }

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -3,15 +3,19 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "tsc && vitest test"
+    "test": "tsc && vitest test",
+    "eql:download": "curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql",
+    "eql:install": "cat sql/cipherstash-encrypt.sql | docker exec -i protect-ffi-postgres psql postgresql://cipherstash:password@postgres:5432/cipherstash -f-"
   },
   "author": "",
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@cipherstash/protect-ffi": ".."
+    "@cipherstash/protect-ffi": "..",
+    "pg": "^8.13.3"
   },
   "devDependencies": {
+    "@types/pg": "^8.11.11",
     "typescript": "^5.3.3",
     "vitest": "^3.0.7"
   }

--- a/integration-tests/tests/postgres.test.ts
+++ b/integration-tests/tests/postgres.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test, beforeAll, beforeEach } from 'vitest'
+import {
+  decrypt,
+  encrypt,
+  newClient,
+  encryptBulk,
+  decryptBulk,
+} from '@cipherstash/protect-ffi'
+import { Client } from 'pg'
+
+describe('postgres', async () => {
+  const protectClient = await newClient(encryptConfig())
+  const pg = new Client()
+  await pg.connect()
+
+  beforeAll(async () => {
+    // called once before all tests run
+    await pg.query(`
+      CREATE TABLE encrypted (
+        id SERIAL PRIMARY KEY,
+        encrypted_text cs_encrypted_v1
+      )
+    `)
+
+    // clean up function, called once after all tests run
+    return async () => {
+      await pg.query('DROP TABLE ENCRYPTED')
+      await pg.end()
+    }
+  })
+
+  beforeEach(async () => {
+    // called once before each test run
+    await pg.query('BEGIN')
+
+    // clean up function, called once after each test run
+    return async () => {
+      await pg.query('ROLLBACK')
+    }
+  })
+
+  test('can round-trip encrypt and decrypt', async () => {
+    const originalPlaintext = 'abc'
+
+    const ciphertext = await encrypt(
+      protectClient,
+      originalPlaintext,
+      'email',
+      'users',
+    )
+
+    await pg.query('INSERT INTO encrypted (encrypted_text) VALUES ($1)', [
+      ciphertext,
+    ])
+
+    const res = await pg.query('SELECT * FROM encrypted')
+
+    expect(res.rowCount).toBe(1)
+
+    const decrypted = await decrypt(protectClient, res.rows[0].encrypted_text.c)
+
+    expect(decrypted).toBe(originalPlaintext)
+  })
+
+  test('can order by an ORE index', async () => {
+    const ciphertexts = await encryptBulk(protectClient, [
+      {
+        plaintext: 'ccc',
+        column: 'email',
+        table: 'users',
+      },
+      {
+        plaintext: 'aaa',
+        column: 'email',
+        table: 'users',
+      },
+      {
+        plaintext: 'bbb',
+        column: 'email',
+        table: 'users',
+      },
+    ])
+
+    await pg.query(
+      'INSERT INTO encrypted (encrypted_text) VALUES ($1), ($2), ($3)',
+      ciphertexts,
+    )
+
+    const res = await pg.query(`
+      SELECT encrypted_text FROM encrypted
+      ORDER BY cs_ore_64_8_v1(encrypted_text)
+    `)
+
+    const decrypted = await decryptBulk(
+      protectClient,
+      res.rows.map((row) => ({ ciphertext: row.encrypted_text.c })),
+    )
+
+    expect(decrypted).toEqual(['aaa', 'bbb', 'ccc'])
+  })
+
+  test('can use a match query', async () => {
+    const ciphertexts = await encryptBulk(protectClient, [
+      {
+        plaintext: 'aaa bbb',
+        column: 'email',
+        table: 'users',
+      },
+      {
+        plaintext: 'aaa ccc',
+        column: 'email',
+        table: 'users',
+      },
+    ])
+
+    await pg.query(
+      'INSERT INTO encrypted (encrypted_text) VALUES ($1), ($2)',
+      ciphertexts,
+    )
+
+    const res = await pg.query(
+      `
+      SELECT encrypted_text FROM encrypted
+      WHERE cs_match_v1(encrypted_text) @> cs_match_v1($1)
+      `,
+      [await encrypt(protectClient, 'ccc', 'email', 'users')],
+    )
+
+    const decrypted = await decryptBulk(
+      protectClient,
+      res.rows.map((row) => ({ ciphertext: row.encrypted_text.c })),
+    )
+
+    expect(decrypted).toEqual(['aaa ccc'])
+  })
+
+  test('can use an exact query', async () => {
+    const ciphertexts = await encryptBulk(protectClient, [
+      {
+        plaintext: 'a',
+        column: 'email',
+        table: 'users',
+      },
+      {
+        plaintext: 'b',
+        column: 'email',
+        table: 'users',
+      },
+    ])
+
+    await pg.query(
+      'INSERT INTO encrypted (encrypted_text) VALUES ($1), ($2)',
+      ciphertexts,
+    )
+
+    const res = await pg.query(
+      `
+      SELECT encrypted_text FROM encrypted
+      WHERE cs_unique_v1(encrypted_text) = cs_unique_v1($1)
+      `,
+      [await encrypt(protectClient, 'b', 'email', 'users')],
+    )
+
+    const decrypted = await decryptBulk(
+      protectClient,
+      res.rows.map((row) => ({ ciphertext: row.encrypted_text.c })),
+    )
+
+    expect(decrypted).toEqual(['b'])
+  })
+})
+
+function encryptConfig() {
+  return JSON.stringify({
+    v: 1,
+    tables: {
+      users: {
+        email: {
+          indexes: {
+            ore: {},
+            match: {
+              tokenizer: {
+                kind: 'ngram',
+                token_length: 3,
+              },
+              token_filters: [
+                {
+                  kind: 'downcase',
+                },
+              ],
+              k: 6,
+              m: 2048,
+              include_original: false,
+            },
+            unique: {},
+          },
+        },
+      },
+    },
+  })
+}


### PR DESCRIPTION
This change adds integration tests against Postgres. https://github.com/cipherstash/protectjs-ffi/pull/17 added a basic integration test for encryption and decryption (without Postgres). This change builds on https://github.com/cipherstash/protectjs-ffi/pull/17 by adding in tests against Postgres.

Tests include:
- Encrypting, writing to PG, reading the value back out, and decrypting
- `ORDER BY` with an ORE index
- `WHERE` with a match index
- `WHERE` with a unique (exact) index