### PR TITLE
Bump EQL to v2.0.2 and cipherstash-client to v0.22.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     env:
-      CS_WORKSPACE_ID: ${{ secrets.CS_WORKSPACE_ID }}
+      CS_WORKSPACE_CRN: ${{ secrets.CS_WORKSPACE_CRN }}
       CS_CLIENT_ACCESS_KEY: ${{ secrets.CS_CLIENT_ACCESS_KEY }}
       CS_CLIENT_ID: ${{ secrets.CS_CLIENT_ID }}
       CS_CLIENT_KEY: ${{ secrets.CS_CLIENT_KEY }}
@@ -91,7 +91,7 @@ jobs:
       - name: Create .env file in ./integration-tests/
         run: |
           cat << EOF > ./integration-tests/.env
-          CS_WORKSPACE_ID=${{ secrets.CS_WORKSPACE_ID }}
+          CS_WORKSPACE_CRN=${{ secrets.CS_WORKSPACE_CRN }}
           CS_CLIENT_ID=${{ secrets.CS_CLIENT_ID }}
           CS_CLIENT_KEY=${{ secrets.CS_CLIENT_KEY }}
           CS_CLIENT_ACCESS_KEY=${{ secrets.CS_CLIENT_ACCESS_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 dependencies = [
+ "serde",
  "zeroize",
 ]
 
@@ -152,6 +153,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +236,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -389,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.18.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099b1db6cf37b0ca36e9c8e0c2dade20f2035804e225f52475d44e750dd5dd5"
+checksum = "0f85784b109d3cacec64a735ca5ac791ef4e9c4d1d451156dd3bb513c9b4ddf0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -406,6 +468,7 @@ dependencies = [
  "cipherstash-config",
  "cipherstash-core",
  "cllw-ore",
+ "cts-common",
  "derive_more",
  "dirs",
  "futures",
@@ -440,7 +503,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "winnow 0.6.20",
+ "winnow 0.6.26",
  "zeroize",
  "zerokms-protocol",
 ]
@@ -551,6 +614,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cts-common"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "058540fce9a147af37cab4f55a5f9d8ae7f35f66efeec58c08cce6beb173d9c3"
+dependencies = [
+ "arrayvec",
+ "axum",
+ "base32",
+ "diesel",
+ "fake 3.1.0",
+ "http",
+ "miette",
+ "nom",
+ "rand",
+ "regex",
+ "serde",
+ "thiserror 1.0.69",
+ "url",
+ "vitaminc",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,6 +655,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.90",
 ]
 
@@ -621,6 +707,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
+name = "diesel"
+version = "2.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff3e1edb1f37b4953dd5176916347289ed43d7119cc2e6c7c3f7849ff44ea506"
+dependencies = [
+ "chrono",
+ "diesel_derives",
+ "uuid",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "2.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d4216021b3ea446fd2047f5c8f8fe6e98af34508a254a01e4d6bc1e844f84d"
+dependencies = [
+ "diesel_table_macro_syntax",
+ "dsl_auto_type",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "diesel_table_macro_syntax"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+dependencies = [
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,10 +782,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "dsl_auto_type"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139ae9aca7527f85f26dd76483eb38533fd84bd571065da1739656ef71c5ff5b"
+dependencies = [
+ "darling",
+ "either",
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "dummy"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cac124e13ae9aa56acc4241f8c8207501d93afdd8d8e62f0c1f2e12f6508c65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "dummy"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abcba80bdf851db5616e27ff869399468e2d339d7c6480f5887681e6bdfc2186"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -709,9 +854,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
- "dummy",
+ "dummy 0.8.0",
  "rand",
  "uuid",
+]
+
+[[package]]
+name = "fake"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef603df4ba9adbca6a332db7da6f614f21eafefbaf8e087844e452fdec152d0"
+dependencies = [
+ "deunicode",
+ "dummy 0.9.2",
+ "rand",
 ]
 
 [[package]]
@@ -972,6 +1128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1145,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1322,6 +1485,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1604,15 @@ dependencies = [
  "quote",
  "syn 2.0.90",
  "syn-mid",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1799,6 +1977,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.8",
  "tokio",
+ "winnow 0.6.26",
 ]
 
 [[package]]
@@ -2153,6 +2332,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2262,6 +2447,16 @@ dependencies = [
  "itoa",
  "memchr",
  "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59fab13f937fa393d08645bf3a84bdfe86e296747b506ada67bb15f10f218b2a"
+dependencies = [
+ "itoa",
  "serde",
 ]
 
@@ -2382,6 +2577,12 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -2645,6 +2846,28 @@ dependencies = [
  "toml_datetime",
  "winnow 0.7.3",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
 
 [[package]]
 name = "tower-service"
@@ -3147,9 +3370,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]
@@ -3279,7 +3502,7 @@ dependencies = [
  "async-trait",
  "base64",
  "cipherstash-config",
- "fake",
+ "fake 2.10.0",
  "opaque-debug",
  "rand",
  "serde",

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ These tests use the local build of Rust and JavaScript artifacts to test `@ciphe
 
 These tests rely on:
 
-- CipherStash to be configured (via `.toml` config or environment variables), and 
+- CipherStash to be configured (via `.toml` config or environment variables), and
 - Environment variables for Postgres to be set
 
 Example environment variables:
@@ -134,7 +134,7 @@ Example environment variables:
 CS_CLIENT_ID=
 CS_CLIENT_KEY=
 CS_CLIENT_ACCESS_KEY=
-CS_WORKSPACE_ID=
+CS_WORKSPACE_CRN=
 PGPORT=5432
 PGDATABASE=cipherstash
 PGUSER=cipherstash

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cipherstash-client = "0.18.0"
+cipherstash-client = "0.22.0"
 hex = "0.4.3"
 neon = "1"
 once_cell = "1.20.2"
@@ -19,3 +19,7 @@ serde = "1.0.218"
 serde_json = "1.0.139"
 thiserror = "2.0.8"
 tokio = { version = "1", features = ["full"] }
+# cipherstash-client specifies winnow 0.6.20 in its deps, but uses exports from `winnow::prelude`
+# that aren't available until later versions. 0.6.26 is what cipherstash-client uses in its lockfile
+# at the time of this change. Using 0.6.26 prevents compiler errors due to missing exports in 0.6.20.
+winnow = "0.6.26"

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -45,11 +45,11 @@ pub enum Encrypted {
     Ciphertext {
         #[serde(rename = "c")]
         ciphertext: String,
-        #[serde(rename = "o")]
+        #[serde(rename = "ob")]
         ore_index: Option<Vec<String>>,
-        #[serde(rename = "m")]
+        #[serde(rename = "bf")]
         match_index: Option<Vec<u16>>,
-        #[serde(rename = "u")]
+        #[serde(rename = "hm")]
         unique_index: Option<String>,
         #[serde(rename = "i")]
         identifier: Identifier,
@@ -583,13 +583,13 @@ fn to_eql_encrypted(
                 match_index: indexes.match_index,
                 ore_index: indexes.ore_index,
                 unique_index: indexes.unique_index,
-                version: 1,
+                version: 2,
             })
         }
         encryption::Encrypted::SteVec(ste_vec_index) => Ok(Encrypted::SteVec {
             identifier: identifier.to_owned(),
             ste_vec_index,
-            version: 1,
+            version: 2,
         }),
     }
 }
@@ -621,26 +621,26 @@ fn eql_encrypted_to_js<'cx, C: Context<'cx>>(
 
     if let Some(ore_index) = ore_index {
         let o = js_array_from_string_vec(ore_index, cx)?;
-        obj.set(cx, "o", o)?;
+        obj.set(cx, "ob", o)?;
     } else {
         let o = cx.null();
-        obj.set(cx, "o", o)?;
+        obj.set(cx, "ob", o)?;
     }
 
     if let Some(match_index) = match_index {
         let m = js_array_from_u16_vec(match_index, cx)?;
-        obj.set(cx, "m", m)?;
+        obj.set(cx, "bf", m)?;
     } else {
         let m = cx.null();
-        obj.set(cx, "m", m)?;
+        obj.set(cx, "bf", m)?;
     }
 
     if let Some(unique_index) = unique_index {
         let u = cx.string(unique_index);
-        obj.set(cx, "u", u)?;
+        obj.set(cx, "hm", u)?;
     } else {
         let u = cx.null();
-        obj.set(cx, "u", u)?;
+        obj.set(cx, "hm", u)?;
     }
 
     let i = cx.empty_object();
@@ -656,7 +656,10 @@ fn eql_encrypted_to_js<'cx, C: Context<'cx>>(
     let v = cx.number(version);
     obj.set(cx, "v", v)?;
 
-    Ok(obj)
+    let composite: Handle<JsObject> = cx.empty_object();
+
+    composite.set(cx, "data", obj)?;
+    Ok(composite)
 }
 
 fn format_index_term_binary(bytes: &Vec<u8>) -> String {

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1,7 +1,8 @@
 use cipherstash_client::{
     config::{
         console_config::ConsoleConfig, cts_config::CtsConfig, errors::ConfigError,
-        zero_kms_config::ZeroKMSConfig, EnvSource, CIPHERSTASH_SECRET_TOML, CIPHERSTASH_TOML,
+        zero_kms_config::ZeroKMSConfig, CipherStashConfigFile, CipherStashSecretConfigFile,
+        EnvSource, FileSource,
     },
     credentials::{ServiceCredentials, ServiceToken},
     encryption::{
@@ -120,8 +121,8 @@ async fn new_client_inner(encrypt_config: EncryptConfig) -> Result<Client, Error
     let zerokms_config = ZeroKMSConfig::builder()
         .add_source(EnvSource::default())
         // Both files are optional and ignored if the file doesn't exist
-        .add_source(CIPHERSTASH_SECRET_TOML.optional())
-        .add_source(CIPHERSTASH_TOML.optional())
+        .add_source(FileSource::<CipherStashSecretConfigFile>::default().optional())
+        .add_source(FileSource::<CipherStashConfigFile>::default().optional())
         .console_config(&console_config)
         .cts_config(&cts_config)
         .build_with_client_key()?;

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -656,10 +656,7 @@ fn eql_encrypted_to_js<'cx, C: Context<'cx>>(
     let v = cx.number(version);
     obj.set(cx, "v", v)?;
 
-    let composite: Handle<JsObject> = cx.empty_object();
-
-    composite.set(cx, "data", obj)?;
-    Ok(composite)
+    Ok(obj)
 }
 
 fn format_index_term_binary(bytes: &Vec<u8>) -> String {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tsc && vitest test",
-    "eql:download": "curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/download/eql-2.0.1/cipherstash-encrypt.sql",
+    "eql:download": "curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/download/eql-2.0.2/cipherstash-encrypt.sql",
     "eql:install": "cat sql/cipherstash-encrypt.sql | docker exec -i protect-ffi-postgres psql postgresql://cipherstash:password@postgres:5432/cipherstash -f-"
   },
   "author": "",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tsc && vitest test",
-    "eql:download": "curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/latest/download/cipherstash-encrypt.sql",
+    "eql:download": "curl -sLo sql/cipherstash-encrypt.sql https://github.com/cipherstash/encrypt-query-language/releases/download/eql-2.0.1/cipherstash-encrypt.sql",
     "eql:install": "cat sql/cipherstash-encrypt.sql | docker exec -i protect-ffi-postgres psql postgresql://cipherstash:password@postgres:5432/cipherstash -f-"
   },
   "author": "",

--- a/integration-tests/tests/index.test.ts
+++ b/integration-tests/tests/index.test.ts
@@ -35,7 +35,7 @@ describe('encrypt and decrypt', async () => {
       table: 'users',
     })
 
-    const decrypted = await decrypt(client, ciphertext.c)
+    const decrypted = await decrypt(client, ciphertext.data.c)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -54,7 +54,7 @@ describe('encrypt and decrypt', async () => {
       undefined,
     )
 
-    const decrypted = await decrypt(client, ciphertext.c, undefined)
+    const decrypted = await decrypt(client, ciphertext.data.c, undefined)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -81,7 +81,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map(({ c }) => ({ ciphertext: c })),
+      ciphertexts.map(({ data }) => ({ ciphertext: data.c })),
     )
 
     expect(decrypted).toEqual([plaintextOne, plaintextTwo])
@@ -111,7 +111,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map(({ c }) => ({ ciphertext: c })),
+      ciphertexts.map(({ data }) => ({ ciphertext: data.c })),
       undefined,
     )
 

--- a/integration-tests/tests/index.test.ts
+++ b/integration-tests/tests/index.test.ts
@@ -35,7 +35,7 @@ describe('encrypt and decrypt', async () => {
       table: 'users',
     })
 
-    const decrypted = await decrypt(client, ciphertext.data.c)
+    const decrypted = await decrypt(client, ciphertext.c)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -54,7 +54,7 @@ describe('encrypt and decrypt', async () => {
       undefined,
     )
 
-    const decrypted = await decrypt(client, ciphertext.data.c, undefined)
+    const decrypted = await decrypt(client, ciphertext.c, undefined)
 
     expect(decrypted).toBe(originalPlaintext)
   })
@@ -81,7 +81,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map(({ data }) => ({ ciphertext: data.c })),
+      ciphertexts.map(({ c }) => ({ ciphertext: c })),
     )
 
     expect(decrypted).toEqual([plaintextOne, plaintextTwo])
@@ -111,7 +111,7 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const decrypted = await decryptBulk(
       client,
-      ciphertexts.map(({ data }) => ({ ciphertext: data.c })),
+      ciphertexts.map(({ c }) => ({ ciphertext: c })),
       undefined,
     )
 

--- a/integration-tests/tests/postgres.test.ts
+++ b/integration-tests/tests/postgres.test.ts
@@ -14,10 +14,10 @@ describe('postgres', async () => {
   const pg = new Client()
   await pg.connect()
 
+  // called once before all tests run
   beforeAll(async () => {
     await pg.query('DROP TABLE IF EXISTS encrypted')
 
-    // called once before all tests run
     await pg.query(`
       CREATE TABLE encrypted (
         id SERIAL PRIMARY KEY,
@@ -25,7 +25,9 @@ describe('postgres', async () => {
       )
     `)
 
-    // TODO: add check constraint or use domain type inside composite type.
+    await pg.query(
+      "SELECT eql_v2.add_encrypted_constraint('encrypted', 'encrypted_text')",
+    )
 
     // clean up function, called once after all tests run
     return async () => {

--- a/src/index.cts
+++ b/src/index.cts
@@ -74,16 +74,14 @@ export type Context = {
 }
 
 export type Encrypted = {
-  data: {
-    k: string
+  k: string
+  c: string
+  ob: string[] | null
+  bf: number[] | null
+  hm: string | null
+  i: {
     c: string
-    ob: string[] | null
-    bf: number[] | null
-    hm: string | null
-    i: {
-      c: string
-      t: string
-    }
-    v: number
+    t: string
   }
+  v: number
 }

--- a/src/index.cts
+++ b/src/index.cts
@@ -74,14 +74,16 @@ export type Context = {
 }
 
 export type Encrypted = {
-  k: string
-  c: string
-  o: string[] | null
-  m: number[] | null
-  u: string | null
-  i: {
+  data: {
+    k: string
     c: string
-    t: string
+    ob: string[] | null
+    bf: number[] | null
+    hm: string | null
+    i: {
+      c: string
+      t: string
+    }
+    v: number
   }
-  v: number
 }


### PR DESCRIPTION
Changes:
- Bump EQL to v2.0.2
  - Fix up property names in encrypted EQL payload
  - Bump version in `v` field to `2`
  - Add casts on EQL types where needed in PG tests
  - Fix up EQL function names and remove unnecessary function calls in PG tests
- Bump `cipherstash-client` to v0.22.0
  - Use workspace CRN instead of workspace ID in config
  - Use new file sources for CipherStash TOML files