### PR TITLE
Bump cipherstash-client to v0.22.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.22.0"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f85784b109d3cacec64a735ca5ac791ef4e9c4d1d451156dd3bb513c9b4ddf0"
+checksum = "8a9e8e35918bb0873f1b365a35345cfdd5482b8a2c0ab2330381972623e32274"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -1977,7 +1977,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.8",
  "tokio",
- "winnow 0.6.26",
 ]
 
 [[package]]

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cipherstash-client = "0.22.0"
+cipherstash-client = "0.22.1"
 hex = "0.4.3"
 neon = "1"
 once_cell = "1.20.2"
@@ -19,7 +19,3 @@ serde = "1.0.218"
 serde_json = "1.0.139"
 thiserror = "2.0.8"
 tokio = { version = "1", features = ["full"] }
-# cipherstash-client specifies winnow 0.6.20 in its deps, but uses exports from `winnow::prelude`
-# that aren't available until later versions. 0.6.26 is what cipherstash-client uses in its lockfile
-# at the time of this change. Using 0.6.26 prevents compiler errors due to missing exports in 0.6.20.
-winnow = "0.6.26"


### PR DESCRIPTION
v0.22.1 includes fixes for:
- compilation failures when invalid Winnow version was resolved
- `WORKSPACE_CRN` config loading precedence