### PR TITLE
Chore: bump cipherstash-client to v0.22.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9e8e35918bb0873f1b365a35345cfdd5482b8a2c0ab2330381972623e32274"
+checksum = "0168885dfe967dc3884a51e415ce15c82343b7fd8be36b08d39f25f4fc727064"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cipherstash-client = "0.22.1"
+cipherstash-client = "0.22.2"
 hex = "0.4.3"
 neon = "1"
 once_cell = "1.20.2"


### PR DESCRIPTION
v0.22.2 of cipherstash-client includes a fix for the default paths used for loading cipherstash.toml and cipherstash.secret.toml.