### PR TITLE
Add `clientOpts` to `newClient`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,6 +1970,7 @@ name = "protect-ffi"
 version = "0.1.0"
 dependencies = [
  "cipherstash-client",
+ "cts-common",
  "hex",
  "neon",
  "once_cell",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -12,6 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 cipherstash-client = "0.22.2"
+cts-common = { version = "0.3.0", default-features = false }
 hex = "0.4.3"
 neon = "1"
 once_cell = "1.20.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.14.2",
+      "version": "0.15.0-0",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cipherstash/protect-ffi",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "os": [
     "darwin"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "os": [
     "linux"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
-  "version": "0.14.2",
+  "version": "0.15.0-0",
   "os": [
     "win32"
   ],

--- a/src/index.cts
+++ b/src/index.cts
@@ -11,7 +11,10 @@ export type Client = { readonly [sym]: unknown }
 // Use this declaration to assign types to the protect-ffi's exports,
 // which otherwise default to `any`.
 declare module './load.cjs' {
-  function newClient(encryptSchema: string): Promise<Client>
+  function newClient(
+    encryptSchema: string,
+    clientOpts?: string,
+  ): Promise<Client>
   function encrypt(
     client: Client,
     plaintext: EncryptPayload,


### PR DESCRIPTION
This change adds an optional `clientOpts` argument to `newClient`.

This value is a JSON-encoded string. The current options are (note that options are snake_cased for consistency with the first arg, the encrypt schema):
- `client_key`
- `client_id`
- `access_key`
- `workspace_crn`

Also note that env vars and TOML files both take precedence over the `clientOpts` arg (due to how precedence works in `cipherstash-client`).

Example usage:
```
newClient(
  JSON.stringify({tables: {}, v: 1}),
  JSON.stringify({
    workspace_crn: 'crn',
    access_key: 'access_key',
    client_id: 'client_id',
    client_key: 'client_key'
  })
)
```

This is admittedly ugly, but it gets the job done. We should take a look at refactoring this after 1) the Neon version bump and 2) reworking config handling in `cipherstash-client`.

The Neon version bump should remove the need for passing around strings and calling `JSON.stringify`. Reworking `cipherstash-client` should fix the precedence issue (and hopefully make the config API more ergonomic).