### PR TITLE
fix: bump Slab version to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2669,9 +2669,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
This change bumps the version of Slab to 0.4.11 to fix up a vulnerability alert. See https://github.com/rustsec/advisory-db/pull/2358.