### PR TITLE
feat: add isEncrypted function and corresponding tests for validation

### DIFF
--- a/integration-tests/tests/scalar.test.ts
+++ b/integration-tests/tests/scalar.test.ts
@@ -2,14 +2,11 @@ import 'dotenv/config'
 import { describe, expect, test } from 'vitest'
 
 import {
-  type CastAs,
   decrypt,
-  decryptBulk,
-  decryptBulkFallible,
   encrypt,
-  encryptBulk,
   type Identifier,
   newClient,
+  isEncrypted,
 } from '@cipherstash/protect-ffi'
 
 // Import a shared encryptConfig from common.js
@@ -42,6 +39,8 @@ describe.each(cases)(
           plaintext,
           ...identifier,
         })
+
+        expect(isEncrypted(ciphertext)).toBe(true)
 
         const decrypted = await decrypt(client, { ciphertext })
         expect(decrypted).toBe(plaintext)

--- a/src/index.cts
+++ b/src/index.cts
@@ -4,6 +4,7 @@ export {
   newClient,
   encrypt,
   encryptBulk,
+  isEncrypted,
   decrypt,
   decryptBulk,
   decryptBulkFallible,
@@ -20,6 +21,7 @@ declare module './load.cjs' {
   function newClient(opts: NewClientOptions): Promise<Client>
   function encrypt(client: Client, opts: EncryptOptions): Promise<Encrypted>
   function decrypt(client: Client, opts: DecryptOptions): Promise<JsPlaintext>
+  function isEncrypted(encrypted: Encrypted): boolean
   function encryptBulk(
     client: Client,
     opts: EncryptBulkOptions,
@@ -57,17 +59,34 @@ export type Context = {
   identityClaim: string[]
 }
 
-export type Encrypted = {
-  k: string
-  c: string
-  ob: string[] | null
-  bf: number[] | null
-  hm: string | null
-  i: {
-    c: string
-    t: string
-  }
-  v: number
+export type Encrypted =
+  | {
+      k: 'ct'
+      c: string
+      ob: string[] | null
+      bf: number[] | null
+      hm: string | null
+      i: {
+        c: string
+        t: string
+      }
+      v: number
+    }
+  | {
+      k: 'sv'
+      sv: SteVecEncryptedEntry[]
+      i: {
+        c: string
+        t: string
+      }
+      v: number
+    }
+
+export type SteVecEncryptedEntry = {
+  tokenized_selector: string
+  term: string
+  record: string
+  parent_is_array: boolean
 }
 
 export type EncryptConfig = {


### PR DESCRIPTION
* Extends the `Encrypted` type (ts) to be the union of a standard EQL and an SteVec (to mirror the EQL enum in Rust)
* Adds an `isEncrypted` FFI function and TS spec