### PR TITLE
feat: support date and timestamp plaintexts

### DIFF
--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+chrono = "0.4.42"
 cipherstash-client = { version = "=0.34.1-alpha.2", features = ["tokio"] }
 cts-common = { version = "=0.34.1-alpha.2", default-features = false }
 stack-profile = { version = "=0.34.1-alpha.2" }
@@ -25,6 +26,5 @@ tokio = { version = "1", features = ["full"] }
 vitaminc = { version = "=0.1.0-pre4.2", features = [ "random", "protected" ] }
 
 [dev-dependencies]
-chrono = "0.4.42"
 quickcheck = "1.0.3"
 quickcheck_macros = "1.0.3"

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -75,6 +75,7 @@ pub enum CastAs {
     #[default]
     String,
     Text,
+    Timestamp,
     Json,
 }
 
@@ -143,6 +144,7 @@ impl From<CastAs> for ColumnType {
             CastAs::Number => ColumnType::Float,
             CastAs::String => ColumnType::Utf8Str,
             CastAs::Text => ColumnType::Utf8Str,
+            CastAs::Timestamp => ColumnType::Timestamp,
             CastAs::Json => ColumnType::JsonB,
         }
     }
@@ -234,6 +236,7 @@ fn cast_as_name(cast_as: &CastAs) -> &'static str {
         CastAs::Number => "number",
         CastAs::String => "string",
         CastAs::Text => "text",
+        CastAs::Timestamp => "timestamp",
         CastAs::Json => "json",
     }
 }
@@ -294,6 +297,51 @@ mod tests {
         assert_eq!(column.cast_type, ColumnType::Float);
         assert_eq!(column.name, "favourite_int");
         assert!(column.indexes.is_empty());
+    }
+
+    #[test]
+    fn can_parse_timestamp_cast_as() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "events": {
+                    "occurred_at": {
+                        "cast_as": "timestamp"
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("events", "occurred_at");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(column.cast_type, ColumnType::Timestamp);
+        assert_eq!(column.name, "occurred_at");
+    }
+
+    #[test]
+    fn can_parse_date_cast_as() {
+        let json = json!({
+            "v": 1,
+            "tables": {
+                "events": {
+                    "occurred_on": {
+                        "cast_as": "date"
+                    }
+                }
+            }
+        });
+
+        let encrypt_config = parse(json);
+
+        let ident = Identifier::new("events", "occurred_on");
+
+        let column = encrypt_config.get(&ident).expect("column exists");
+
+        assert_eq!(column.cast_type, ColumnType::Date);
     }
 
     #[test]

--- a/crates/protect-ffi/src/js_plaintext.rs
+++ b/crates/protect-ffi/src/js_plaintext.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 use cipherstash_client::encryption::{Plaintext, TryFromPlaintext, TypeParseError};
 use cipherstash_client::schema::ColumnType;
 use rust_decimal::Decimal;
@@ -7,9 +8,18 @@ use vitaminc::protected::OpaqueDebug;
 #[derive(Deserialize, Serialize, OpaqueDebug, PartialEq)]
 #[serde(untagged)]
 pub(crate) enum JsPlaintext {
+    // `String` is first so that RFC 3339 strings (as produced by
+    // `Date.prototype.toJSON()` on the JS side) deserialize as strings, not
+    // as `Date`. `to_plaintext_with_type` parses them into `Plaintext::Date` /
+    // `Plaintext::Timestamp` when the column's `cast_as` requires it.
     String(String),
     Number(f64),
     Boolean(bool),
+    // Produced only on the decrypt path from `Plaintext::NaiveDate` /
+    // `Plaintext::Timestamp`. Serializes as a plain RFC 3339 string via
+    // chrono's default impl, so the JS side receives a string and can call
+    // `new Date(...)` if needed.
+    Date(DateTime<Utc>),
     JsonB(serde_json::Value),
 }
 
@@ -20,6 +30,7 @@ impl From<JsPlaintext> for Plaintext {
             JsPlaintext::Number(n) => Plaintext::Float(Some(n)),
             JsPlaintext::Boolean(b) => Plaintext::Boolean(Some(b)),
             JsPlaintext::JsonB(j) => Plaintext::JsonB(Some(j)),
+            JsPlaintext::Date(dt) => Plaintext::Timestamp(Some(dt)),
         }
     }
 }
@@ -41,6 +52,14 @@ impl TryFrom<Plaintext> for JsPlaintext {
             Plaintext::BigInt(Some(n)) => Ok(JsPlaintext::Number(n as f64)),
             Plaintext::Float(Some(n)) => Ok(JsPlaintext::Number(n)),
             Plaintext::Boolean(Some(b)) => Ok(JsPlaintext::Boolean(b)),
+            Plaintext::NaiveDate(Some(nd)) => {
+                // Promote date-only to midnight UTC so the JS-visible form is a
+                // full timestamp.
+                let dt =
+                    Utc.from_utc_datetime(&nd.and_hms_opt(0, 0, 0).expect("00:00:00 is valid"));
+                Ok(JsPlaintext::Date(dt))
+            }
+            Plaintext::Timestamp(Some(ts)) => Ok(JsPlaintext::Date(ts)),
             _ => Err(TypeParseError("Unsupported type".to_string())),
         }
     }
@@ -49,19 +68,25 @@ impl TryFrom<Plaintext> for JsPlaintext {
 impl JsPlaintext {
     /// Convert JsPlaintext to Plaintext based on a target ColumnType.
     ///
-    /// This conversion follows the rule that type coercion is allowed but parsing is not.
-    /// For example:
-    /// - JsPlaintext::Number to Plaintext::BigInt is allowed (coercion with truncation)
-    /// - JsPlaintext::String to Plaintext::BigInt is NOT allowed (would require parsing)
+    /// The storage type is driven by `cast_as`, not by the input variant.
+    /// A JS Date (arriving as an RFC 3339 string via `Date.prototype.toJSON()`
+    /// or as a `JsPlaintext::Date` produced by a prior decrypt) can be stored
+    /// as a day-only `Date`, a full `Timestamp`, or an ISO 8601 string.
     pub fn to_plaintext_with_type(
         &self,
         column_type: ColumnType,
     ) -> Result<Plaintext, TypeParseError> {
         match (self, column_type) {
-            // String conversions - only allow to Utf8Str
+            // String conversions - Utf8Str, Date, and Timestamp (the latter two parse).
             (JsPlaintext::String(s), ColumnType::Utf8Str) => {
                 Ok(Plaintext::Utf8Str(Some(s.clone())))
             }
+            (JsPlaintext::String(s), ColumnType::Date) => parse_naive_date(s)
+                .map(|d| Plaintext::NaiveDate(Some(d)))
+                .map_err(|e| TypeParseError(format!("Cannot parse Date: {}", e))),
+            (JsPlaintext::String(s), ColumnType::Timestamp) => parse_timestamp(s)
+                .map(|t| Plaintext::Timestamp(Some(t)))
+                .map_err(|e| TypeParseError(format!("Cannot parse Timestamp: {}", e))),
 
             // Number conversions - allow to numeric types with potential truncation/coercion
             (JsPlaintext::Number(n), ColumnType::Float) => Ok(Plaintext::Float(Some(*n))),
@@ -89,27 +114,58 @@ impl JsPlaintext {
             // JsonB conversions - only allow to JsonB
             (JsPlaintext::JsonB(j), ColumnType::JsonB) => Ok(Plaintext::JsonB(Some(j.clone()))),
 
+            // Date conversions: the value is a full UTC timestamp; cast_as picks
+            // the storage form.
+            (JsPlaintext::Date(dt), ColumnType::Date) => {
+                Ok(Plaintext::NaiveDate(Some(dt.date_naive())))
+            }
+            (JsPlaintext::Date(dt), ColumnType::Timestamp) => Ok(Plaintext::Timestamp(Some(*dt))),
+            (JsPlaintext::Date(dt), ColumnType::Utf8Str) => {
+                Ok(Plaintext::Utf8Str(Some(dt.to_rfc3339())))
+            }
+
             // All other conversions are not allowed - provide helpful error message
             (js_type, col_type) => {
                 let valid_targets = match js_type {
-                    JsPlaintext::String(_) => "Utf8Str (string columns)",
+                    JsPlaintext::String(_) => {
+                        "Utf8Str (string columns), Date, Timestamp (ISO 8601 strings)"
+                    }
                     JsPlaintext::Number(_) => {
                         "Float, BigInt, Int, SmallInt, BigUInt, Decimal (numeric columns)"
                     }
                     JsPlaintext::Boolean(_) => "Boolean (boolean columns)",
                     JsPlaintext::JsonB(_) => "JsonB (json columns)",
+                    JsPlaintext::Date(_) => {
+                        "Date, Timestamp (date/timestamp columns), Utf8Str (ISO 8601 string)"
+                    }
                 };
+                let type_name = js_plaintext_type_name(js_type);
                 Err(TypeParseError(format!(
                     "Cannot convert {} to {:?}. {} values can only be used with: {}. \
                     Check your column's cast_as setting in the encrypt config.",
-                    js_plaintext_type_name(js_type),
-                    col_type,
-                    js_plaintext_type_name(js_type),
-                    valid_targets
+                    type_name, col_type, type_name, valid_targets
                 )))
             }
         }
     }
+}
+
+/// Parse a string into a `NaiveDate`. Accepts full RFC 3339 timestamps (the
+/// common case — JS `Date.prototype.toJSON()` always emits RFC 3339) and also
+/// `YYYY-MM-DD` for callers who pass a bare date.
+fn parse_naive_date(s: &str) -> Result<NaiveDate, String> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+        return Ok(dt.with_timezone(&Utc).date_naive());
+    }
+    NaiveDate::parse_from_str(s, "%Y-%m-%d").map_err(|e| e.to_string())
+}
+
+/// Parse a string into a UTC `DateTime`. Accepts RFC 3339 (the format JS `Date`
+/// objects produce via `toJSON()`).
+fn parse_timestamp(s: &str) -> Result<DateTime<Utc>, String> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|e| e.to_string())
 }
 
 /// Helper function to get a readable type name for error messages
@@ -119,6 +175,7 @@ pub(crate) fn js_plaintext_type_name(js_plaintext: &JsPlaintext) -> &'static str
         JsPlaintext::Number(_) => "Number",
         JsPlaintext::Boolean(_) => "Boolean",
         JsPlaintext::JsonB(_) => "JsonB",
+        JsPlaintext::Date(_) => "Date",
     }
 }
 
@@ -126,6 +183,12 @@ pub(crate) fn js_plaintext_type_name(js_plaintext: &JsPlaintext) -> &'static str
 mod tests {
     use super::*;
     use crate::js_plaintext::JsPlaintext;
+
+    fn sample_dt() -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339("2025-03-14T12:34:56.789Z")
+            .unwrap()
+            .with_timezone(&Utc)
+    }
 
     mod js_plaintext_to_plaintext {
         use super::*;
@@ -164,11 +227,22 @@ mod tests {
                 Plaintext::JsonB(Some(serde_json::json!({"key": "value"})))
             );
         }
+
+        #[test]
+        fn test_date_to_timestamp_plaintext() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let pt: Plaintext = js.into();
+            assert_eq!(
+                pt,
+                Plaintext::Timestamp(Some(t)),
+                "JsPlaintext::Date should map to Plaintext::Timestamp without column-type context"
+            );
+        }
     }
 
     mod plaintext_to_js_plaintext {
         use super::*;
-        use chrono::{DateTime, Utc};
 
         #[quickcheck]
         fn test_utf8str(s: String) {
@@ -213,11 +287,37 @@ mod tests {
         }
 
         #[test]
+        fn test_naive_date_becomes_date_at_midnight_utc() {
+            let d = NaiveDate::from_ymd_opt(2025, 3, 14).unwrap();
+            let pt = Plaintext::NaiveDate(Some(d));
+            let js: JsPlaintext = pt.try_into().unwrap();
+            let expected = Utc.with_ymd_and_hms(2025, 3, 14, 0, 0, 0).unwrap();
+            assert_eq!(
+                js,
+                JsPlaintext::Date(expected),
+                "NaiveDate should promote to midnight UTC on the JS side"
+            );
+        }
+
+        #[test]
+        fn test_timestamp_becomes_date() {
+            let t = sample_dt();
+            let pt = Plaintext::Timestamp(Some(t));
+            let js: JsPlaintext = pt.try_into().unwrap();
+            assert_eq!(
+                js,
+                JsPlaintext::Date(t),
+                "Plaintext::Timestamp should map to JsPlaintext::Date preserving the value"
+            );
+        }
+
+        #[test]
         fn test_unsupported_type() {
-            let ts: DateTime<Utc> = Utc::now();
-            let plaintext_timestamp = Plaintext::Timestamp(Some(ts));
-            let result: Result<JsPlaintext, TypeParseError> = plaintext_timestamp.try_into();
-            assert!(result.is_err());
+            let result: Result<JsPlaintext, TypeParseError> = Plaintext::Int(Some(42)).try_into();
+            assert!(
+                result.is_err(),
+                "Plaintext::Int has no JsPlaintext mapping and should fail"
+            );
         }
     }
 
@@ -338,6 +438,137 @@ mod tests {
             let result = js_number.to_plaintext_with_type(ColumnType::Boolean);
             assert!(result.is_err());
             assert!(result.unwrap_err().0.contains("Cannot convert"));
+        }
+
+        #[test]
+        fn test_iso_date_string_to_date() {
+            let js_string = JsPlaintext::String("2025-03-14".to_string());
+            let result = js_string.to_plaintext_with_type(ColumnType::Date).unwrap();
+            assert_eq!(
+                result,
+                Plaintext::NaiveDate(Some(NaiveDate::from_ymd_opt(2025, 3, 14).unwrap()))
+            );
+        }
+
+        #[test]
+        fn test_rfc3339_string_to_date_truncates_time() {
+            let js_string = JsPlaintext::String("2025-03-14T12:34:56.789Z".to_string());
+            let result = js_string.to_plaintext_with_type(ColumnType::Date).unwrap();
+            assert_eq!(
+                result,
+                Plaintext::NaiveDate(Some(NaiveDate::from_ymd_opt(2025, 3, 14).unwrap()))
+            );
+        }
+
+        #[test]
+        fn test_rfc3339_string_to_timestamp() {
+            let js_string = JsPlaintext::String("2025-03-14T12:34:56.789Z".to_string());
+            let result = js_string
+                .to_plaintext_with_type(ColumnType::Timestamp)
+                .unwrap();
+            assert_eq!(result, Plaintext::Timestamp(Some(sample_dt())));
+        }
+
+        #[test]
+        fn test_invalid_date_string_fails() {
+            let js_string = JsPlaintext::String("not a date".to_string());
+            let result = js_string.to_plaintext_with_type(ColumnType::Date);
+            let err = result.expect_err("unparseable input must fail");
+            assert!(
+                err.0.contains("Cannot parse Date"),
+                "error should name the failing target type, got: {}",
+                err.0
+            );
+            assert!(
+                !err.0.contains("not a date"),
+                "error must not echo the user's input (possible secret leak), got: {}",
+                err.0
+            );
+        }
+
+        #[test]
+        fn test_invalid_timestamp_string_fails() {
+            let js_string = JsPlaintext::String("2025-03-14".to_string()); // date-only, not rfc3339
+            let result = js_string.to_plaintext_with_type(ColumnType::Timestamp);
+            let err =
+                result.expect_err("date-only string must fail as Timestamp (requires RFC 3339)");
+            assert!(
+                err.0.contains("Cannot parse Timestamp"),
+                "error should name the failing target type, got: {}",
+                err.0
+            );
+            assert!(
+                !err.0.contains("2025-03-14"),
+                "error must not echo the user's input (possible secret leak), got: {}",
+                err.0
+            );
+        }
+
+        #[test]
+        fn test_date_value_to_timestamp_column() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let result = js.to_plaintext_with_type(ColumnType::Timestamp).unwrap();
+            assert_eq!(result, Plaintext::Timestamp(Some(t)));
+        }
+
+        #[test]
+        fn test_date_value_to_date_column_truncates() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let result = js.to_plaintext_with_type(ColumnType::Date).unwrap();
+            assert_eq!(
+                result,
+                Plaintext::NaiveDate(Some(NaiveDate::from_ymd_opt(2025, 3, 14).unwrap()))
+            );
+        }
+
+        #[test]
+        fn test_date_value_to_string_column_serializes_rfc3339() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let result = js.to_plaintext_with_type(ColumnType::Utf8Str).unwrap();
+            if let Plaintext::Utf8Str(Some(ref s)) = result {
+                let parsed = DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc);
+                assert_eq!(parsed, t);
+            } else {
+                panic!("Expected Plaintext::Utf8Str");
+            }
+        }
+
+        #[test]
+        fn test_date_value_to_bigint_fails() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let result = js.to_plaintext_with_type(ColumnType::BigInt);
+            assert!(
+                result.is_err(),
+                "Date should not coerce into a numeric column"
+            );
+        }
+
+        #[test]
+        fn test_date_serializes_as_rfc3339_string() {
+            let t = sample_dt();
+            let js = JsPlaintext::Date(t);
+            let s = serde_json::to_string(&js).unwrap();
+            assert_eq!(
+                s, r#""2025-03-14T12:34:56.789Z""#,
+                "Date must serialize as a plain RFC 3339 string so JS callers can build a Date from it"
+            );
+        }
+
+        #[test]
+        fn test_rfc3339_string_deserializes_as_string_not_date() {
+            // `String` precedes `Date` in the untagged enum order, which is load-bearing:
+            // user-supplied strings must never be silently reinterpreted as dates; date
+            // parsing only happens in `to_plaintext_with_type` when the column demands it.
+            let parsed: JsPlaintext =
+                serde_json::from_str(r#""2025-03-14T12:34:56.789Z""#).unwrap();
+            assert!(
+                matches!(parsed, JsPlaintext::String(_)),
+                "RFC 3339 strings must deserialize as JsPlaintext::String, not JsPlaintext::Date"
+            );
         }
 
         #[test]

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -66,6 +66,7 @@ pub enum ReceivedKind {
     JsonObject,
     JsonArray,
     JsonScalar(String),
+    Date,
 }
 
 impl std::fmt::Display for ReceivedKind {
@@ -77,6 +78,7 @@ impl std::fmt::Display for ReceivedKind {
             Self::JsonObject => write!(f, "JSON object"),
             Self::JsonArray => write!(f, "JSON array"),
             Self::JsonScalar(s) => write!(f, "JSON scalar {}", s),
+            Self::Date => write!(f, "Date"),
         }
     }
 }
@@ -657,6 +659,14 @@ fn to_query_plaintext(
                 JsPlaintext::JsonB(_) => {
                     // This is the expected type - proceed
                 }
+                JsPlaintext::Date(_) => {
+                    return Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecTerm,
+                        received: ReceivedKind::Date,
+                        expected: ExpectedKind::JsonObjectOrArray,
+                        hint: QueryInputHint::WrapInObject,
+                    });
+                }
             }
             // Use Store mode to produce sv array for containment matching
             let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::JsonB)?;
@@ -690,6 +700,12 @@ fn to_query_plaintext(
                     JsPlaintext::Boolean(b) => Err(Error::InvalidQueryInput {
                         query_op: QueryOpKind::SteVecDefault,
                         received: ReceivedKind::Boolean(*b),
+                        expected: ExpectedKind::StringPathOrJsonObjectOrArray,
+                        hint: QueryInputHint::UsePathOrObject,
+                    }),
+                    JsPlaintext::Date(_) => Err(Error::InvalidQueryInput {
+                        query_op: QueryOpKind::SteVecDefault,
+                        received: ReceivedKind::Date,
                         expected: ExpectedKind::StringPathOrJsonObjectOrArray,
                         hint: QueryInputHint::UsePathOrObject,
                     }),

--- a/integration-tests/tests/common.ts
+++ b/integration-tests/tests/common.ts
@@ -41,6 +41,21 @@ export const jsonOpaque: EncryptConfig = {
   },
 }
 
+// Config with a date and a timestamp column for testing JS Date round-trips
+export const datesConfig: EncryptConfig = {
+  v: 1,
+  tables: {
+    events: {
+      occurred_on: {
+        cast_as: 'date',
+      },
+      occurred_at: {
+        cast_as: 'timestamp',
+      },
+    },
+  },
+}
+
 // A single JSON column with an ste_vec index
 export const jsonSteVec: EncryptConfig = {
   v: 1,

--- a/integration-tests/tests/dates.test.ts
+++ b/integration-tests/tests/dates.test.ts
@@ -1,0 +1,102 @@
+import 'dotenv/config'
+import { describe, expect, test } from 'vitest'
+
+import {
+  decrypt,
+  decryptBulk,
+  encrypt,
+  encryptBulk,
+  newClient,
+} from '@cipherstash/protect-ffi'
+
+import { datesConfig } from './common.js'
+
+// Dates cross the FFI boundary as ISO 8601 strings (a JSON limitation — there
+// is no native Date type in JSON). Callers who have a JS `Date` pass
+// `d.toISOString()`; decrypt returns an ISO string which the caller can wrap
+// in `new Date(...)` to get a `Date` back.
+
+describe('Date / Timestamp encrypt + decrypt', () => {
+  test('round-trips a Date (as ISO string) through a timestamp column', async () => {
+    const client = await newClient({ encryptConfig: datesConfig })
+    const d = new Date('2025-03-14T12:34:56.789Z')
+
+    const ciphertext = await encrypt(client, {
+      plaintext: d.toISOString(),
+      table: 'events',
+      column: 'occurred_at',
+    })
+
+    const decrypted = await decrypt(client, { ciphertext })
+
+    expect(typeof decrypted).toBe('string')
+    expect(new Date(decrypted as string).toISOString()).toBe(d.toISOString())
+  })
+
+  test('round-trips through a date column (time truncated)', async () => {
+    const client = await newClient({ encryptConfig: datesConfig })
+    const d = new Date('2025-03-14T12:34:56.789Z')
+
+    const ciphertext = await encrypt(client, {
+      plaintext: d.toISOString(),
+      table: 'events',
+      column: 'occurred_on',
+    })
+
+    const decrypted = await decrypt(client, { ciphertext })
+
+    expect(typeof decrypted).toBe('string')
+    // date column stores day-precision; the value comes back as UTC midnight.
+    expect(new Date(decrypted as string).toISOString()).toBe(
+      '2025-03-14T00:00:00.000Z',
+    )
+  })
+
+  test('accepts YYYY-MM-DD for a date column', async () => {
+    const client = await newClient({ encryptConfig: datesConfig })
+
+    const ciphertext = await encrypt(client, {
+      plaintext: '2025-03-14',
+      table: 'events',
+      column: 'occurred_on',
+    })
+
+    const decrypted = await decrypt(client, { ciphertext })
+
+    expect(new Date(decrypted as string).toISOString()).toBe(
+      '2025-03-14T00:00:00.000Z',
+    )
+  })
+
+  test('bulk encrypt/decrypt preserves timestamp values', async () => {
+    const client = await newClient({ encryptConfig: datesConfig })
+    const a = new Date('2024-01-02T03:04:05.000Z')
+    const b = new Date('2025-06-07T08:09:10.500Z')
+
+    const ciphertexts = await encryptBulk(client, {
+      plaintexts: [
+        { plaintext: a.toISOString(), table: 'events', column: 'occurred_at' },
+        { plaintext: b.toISOString(), table: 'events', column: 'occurred_at' },
+      ],
+    })
+
+    const decrypted = await decryptBulk(client, {
+      ciphertexts: ciphertexts.map((c) => ({ ciphertext: c })),
+    })
+
+    expect(decrypted).toHaveLength(2)
+    expect(new Date(decrypted[0] as string).toISOString()).toBe(a.toISOString())
+    expect(new Date(decrypted[1] as string).toISOString()).toBe(b.toISOString())
+  })
+
+  test('rejects an unparseable string for a date column', async () => {
+    const client = await newClient({ encryptConfig: datesConfig })
+    await expect(
+      encrypt(client, {
+        plaintext: 'not a date',
+        table: 'events',
+        column: 'occurred_on',
+      }),
+    ).rejects.toThrowError()
+  })
+})

--- a/src/index.cts
+++ b/src/index.cts
@@ -318,6 +318,7 @@ export type CastAs =
   | 'number'
   | 'string' // deprecated, use text instead but keep for backwards compatibility
   | 'text'
+  | 'timestamp'
   | 'json'
 
 // Extract the tables from a specific config


### PR DESCRIPTION
## Summary

- Fixes a bug where `cast_as: 'date'` was advertised in the config but the plaintext conversion layer had no path to or from date/timestamp types — encrypting to or decrypting from a `date` column failed with "Cannot convert … to Date".
- Adds a new `cast_as: 'timestamp'` → `ColumnType::Timestamp` alongside the existing `'date'` → `ColumnType::Date` (day precision).
- JS Dates cross the FFI as ISO 8601 strings (JSON has no native Date type). Callers pass `d.toISOString()` on encrypt; decrypt returns a plain RFC 3339 string which callers wrap with `new Date(...)` if they want a Date object.
- `JsPlaintext::Date(DateTime<Utc>)` is the Rust-side bridge — produced on decrypt from `Plaintext::NaiveDate` (promoted to midnight UTC) or `Plaintext::Timestamp`, and consumed on re-encrypt paths.

Linear: [CIP-3016](https://linear.app/cipherstash/issue/CIP-3016/protect-ffi-support-date-and-timestamp-plaintexts)

## Notes

- Error messages from date/timestamp parsing no longer echo the input string back to the caller — a value mistakenly routed to a date column (e.g. a secret meant for a text column) won't be reflected in the error.
- Wire format: `{"$cs_type":"date",...}` tagging was considered and rejected in favor of plain RFC 3339 strings — simpler, and users don't need TS-side revival boilerplate.
- The three `(Date, ColumnType::*)` arms in `to_plaintext_with_type` (Date/Timestamp/Utf8Str) let `cast_as` drive the storage form from a single Date value; the `Utf8Str` arm means a Date can also be stored as an ISO string for free.

## Test plan

- [x] `cargo test -p protect-ffi` — 84 Rust unit tests pass, including 18 new tests covering:
  - Plaintext ↔ JsPlaintext round-trips for NaiveDate and Timestamp
  - ISO 8601 and YYYY-MM-DD parsing into Date/Timestamp columns
  - Date value cast to Date (truncate), Timestamp (full), Utf8Str (RFC 3339)
  - Wire format: Date serializes to plain RFC 3339 string
  - Untagged-enum ordering: RFC 3339 strings deserialize as String, not Date
  - Error messages do not echo user input
- [x] `npm run test:typecheck` / `test:unit` / `test:lint` / `test:format` all pass
- [x] `cargo fmt --check` clean
- [x] Integration tests added in `integration-tests/tests/dates.test.ts` covering timestamp round-trip, date column truncation, `YYYY-MM-DD` input, bulk round-trip, and invalid-string rejection (require docker + ZeroKMS credentials to execute)