### PR TITLE
fix(deps): patch aws-lc-sys to 0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,9 +213,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -224,9 +224,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",


### PR DESCRIPTION
Bumps `aws-lc-rs` 1.16.1 → 1.16.3, which transitively bumps `aws-lc-sys` 0.38.0 → 0.40.0 (≥ 0.39.0 fix line).

Addresses:
- [GHSA-9f94-5g5w-gf6r](https://github.com/aws/aws-lc-rs/security/advisories/GHSA-9f94-5g5w-gf6r) — CRL distribution point matching logic error allows revoked certificate to bypass revocation checks.
- [GHSA-394x-vwmw-crm3](https://github.com/aws/aws-lc-rs/security/advisories/GHSA-394x-vwmw-crm3) — CN validation logic error allows certificates with wildcard or raw UTF-8 Unicode CN values to bypass name constraints.

Note: `aws-lc-rs 1.16.1` pins `aws-lc-sys ^0.38.0`, so a `--precise 0.39.0` update is not selectable. Bumping `aws-lc-rs` to 1.16.3 brings in `aws-lc-sys 0.40.0`, which satisfies the fix.

This is an automated security patch update.