### PR TITLE
chore(deps): upgrade cipherstash-client to 0.34.1-alpha.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher 0.4.4",
+ "cipher",
  "cpufeatures 0.2.17",
  "zeroize",
 ]
@@ -47,7 +47,7 @@ checksum = "ae0784134ba9375416d469ec31e7c5f9fa94405049cf08c5ce5b4698be673e0d"
 dependencies = [
  "aead",
  "aes",
- "cipher 0.4.4",
+ "cipher",
  "ctr",
  "polyval",
  "subtle",
@@ -329,19 +329,9 @@ dependencies = [
 
 [[package]]
 name = "block-modes"
-version = "0.8.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
-dependencies = [
- "block-padding",
- "cipher 0.3.0",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
+checksum = "9e2211b0817f061502a8dd9f11a37e879e79763e3c698d2418cf824d8cb2f21e"
 
 [[package]]
 name = "borsh"
@@ -527,15 +517,6 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
@@ -546,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4243825d0277d390bb91d849af518790ef0292877843fadc648a8584e7832268"
+checksum = "9f3d67cc26d8422509d2c20644576124e7344a4bf14ded06c7affa8dc18aabca"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -575,9 +556,10 @@ dependencies = [
  "miette",
  "opaque-debug",
  "open 3.2.0",
+ "orderable-bytes",
  "ore-rs",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "recipher",
  "reqwest",
  "reqwest-middleware",
@@ -610,25 +592,26 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96110c01d214312cffc3ba025ec990281cd391b94ca338c9179080106b4e422d"
+checksum = "283fa04db19f9bf2cb2f09e8c1505a15560310bc50fdc066734072c616aa8ca9"
 dependencies = [
  "bitflags",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cipherstash-core"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86043984aa42bf871e2f1e48af22925b624cf80f22ddbb61c35208a6ada0fe8d"
+checksum = "b5bb7181053c3fc35569e0800fa7510c85ee2bffee21abbd2a7aeb498f5f0972"
 dependencies = [
  "hmac",
  "lazy_static",
  "num-bigint",
- "rand 0.8.5",
+ "rand 0.8.6",
  "regex",
  "sha2",
  "thiserror 1.0.69",
@@ -636,13 +619,16 @@ dependencies = [
 
 [[package]]
 name = "cllw-ore"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c676b8e0a3130e6f8b4398d9aa5b287c3ce7074ac89f1ccf1570ebeb22281629"
+checksum = "5d007a5be83ae12adbd17543f9631d64090d761c029d2f8f7eb8f8ddb2a87caf"
 dependencies = [
  "blake3",
+ "chrono",
  "hex",
+ "orderable-bytes",
  "postgres-types",
+ "rust_decimal",
  "subtle",
  "thiserror 1.0.69",
  "unicode-normalization",
@@ -654,7 +640,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8543454e3c3f5126effff9cd44d562af4e31fb8ce1cc0d3dcd8f084515dbc1aa"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
  "dbl",
  "digest",
 ]
@@ -813,14 +799,14 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
- "cipher 0.4.4",
+ "cipher",
 ]
 
 [[package]]
 name = "cts-common"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a83705e5a4bd4cf7594d1e85ea255dd88fa963f7c857a6576d92c19e8bf3267"
+checksum = "3b26644e630f2e690194c6b61f5b613b768061750f2060cf4db73ddb8058d284"
 dependencies = [
  "arrayvec",
  "base32",
@@ -832,6 +818,7 @@ dependencies = [
  "nom",
  "regex",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tracing",
  "url",
@@ -1080,7 +1067,7 @@ checksum = "2d391ba4af7f1d93f01fcf7b2f29e2bc9348e109dfdbf4dcbdc51dfa38dab0b6"
 dependencies = [
  "deunicode",
  "dummy",
- "rand 0.8.5",
+ "rand 0.8.6",
  "uuid",
 ]
 
@@ -2179,20 +2166,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
-name = "ore-rs"
-version = "0.8.0"
+name = "orderable-bytes"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17ced859adc3f4a6a80568b0b33519a496b00609b0be3b94d9dff136b5f3ec8"
+checksum = "adba0469737879cabc3bdcaa6a7beb4ff7f5bb4aa5d624816c8bb9d425a7d5df"
+dependencies = [
+ "chrono",
+ "rust_decimal",
+]
+
+[[package]]
+name = "ore-rs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77fb65718f1aba7bb7f568db90a2b17a48871d83cd9d1101d19fce449dd8dea"
 dependencies = [
  "aes",
  "block-modes",
  "byteorder",
+ "chrono",
  "hex",
- "hex-literal",
  "lazy_static",
  "num",
- "rand 0.8.5",
+ "orderable-bytes",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
+ "rust_decimal",
  "subtle-ng",
  "thiserror 1.0.69",
  "zeroize",
@@ -2559,9 +2558,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2644,9 +2643,9 @@ dependencies = [
 
 [[package]]
 name = "recipher"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142637705fc952f975681a62dc0772aab3afec9e68955c5539f02cdb711c09aa"
+checksum = "2b3561e1082283a4c064635b7886aa4d24db57a43ac31c55930c10797ab5cdeb"
 dependencies = [
  "aes",
  "async-trait",
@@ -2654,7 +2653,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "opaque-debug",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rand_chacha 0.3.1",
  "serde",
  "serde_cbor",
@@ -2913,7 +2912,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -3310,9 +3309,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stack-auth"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0e7dec4eb94dc017d300640d220248adf139de58227c1fc66c029afb5e4e87"
+checksum = "072e420b2bb179e7627f2e9e5ee4080d1f939c6710ecf91524d52fc87e40cbd0"
 dependencies = [
  "aquamarine",
  "cts-common",
@@ -3336,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "stack-profile"
-version = "0.34.1-alpha.2"
+version = "0.34.1-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235d07d0164b5840489acdb856e3e9e8f8c9dd439c66e9d61f4ad703f2e38796"
+checksum = "1dd61bc4129d2258ec1ba89d742558308560fc0f585f9c24d478685def8efd14"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4901,9 +4900,9 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.7"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cd60c0692b5e140e70cab89017cb6ea0dd24da3966d0966a416b2a5f7fce98b"
+checksum = "0a2f045e2ee975a3d448419245c4621ea8844d2a004c63a96277181dc7cf8483"
 dependencies = [
  "base64",
  "cipherstash-config",
@@ -4911,7 +4910,7 @@ dependencies = [
  "cts-common",
  "fake",
  "opaque-debug",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "static_assertions",
  "thiserror 1.0.69",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -12,9 +12,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 chrono = "0.4.42"
-cipherstash-client = { version = "=0.34.1-alpha.2", features = ["tokio"] }
-cts-common = { version = "=0.34.1-alpha.2", default-features = false }
-stack-profile = { version = "=0.34.1-alpha.2" }
+cipherstash-client = { version = "=0.34.1-alpha.4", features = ["tokio"] }
+cts-common = { version = "=0.34.1-alpha.4", default-features = false }
+stack-profile = { version = "=0.34.1-alpha.4" }
 hex = "0.4.3"
 neon = { version = "1", features = ["serde", "tokio"] }
 once_cell = "1.20.2"

--- a/crates/protect-ffi/src/encrypt_config.rs
+++ b/crates/protect-ffi/src/encrypt_config.rs
@@ -142,10 +142,10 @@ impl From<CastAs> for ColumnType {
             CastAs::Boolean => ColumnType::Boolean,
             CastAs::Date => ColumnType::Date,
             CastAs::Number => ColumnType::Float,
-            CastAs::String => ColumnType::Utf8Str,
-            CastAs::Text => ColumnType::Utf8Str,
+            CastAs::String => ColumnType::Text,
+            CastAs::Text => ColumnType::Text,
             CastAs::Timestamp => ColumnType::Timestamp,
-            CastAs::Json => ColumnType::JsonB,
+            CastAs::Json => ColumnType::Json,
         }
     }
 }
@@ -271,7 +271,7 @@ mod tests {
 
         let column = encrypt_config.get(&ident).expect("column exists");
 
-        assert_eq!(column.cast_type, ColumnType::Utf8Str);
+        assert_eq!(column.cast_type, ColumnType::Text);
         assert!(column.indexes.is_empty());
     }
 
@@ -557,7 +557,7 @@ mod tests {
 
         let column = encrypt_config.get(&ident).expect("column exists");
 
-        assert_eq!(column.cast_type, ColumnType::JsonB);
+        assert_eq!(column.cast_type, ColumnType::Json);
         assert_eq!(
             column.indexes[0].index_type,
             IndexType::SteVec {
@@ -642,6 +642,6 @@ mod tests {
         let config = result.unwrap();
         let ident = Identifier::new("users", "event_data");
         let column = config.get(&ident).expect("column exists");
-        assert_eq!(column.cast_type, ColumnType::JsonB);
+        assert_eq!(column.cast_type, ColumnType::Json);
     }
 }

--- a/crates/protect-ffi/src/js_plaintext.rs
+++ b/crates/protect-ffi/src/js_plaintext.rs
@@ -26,10 +26,10 @@ pub(crate) enum JsPlaintext {
 impl From<JsPlaintext> for Plaintext {
     fn from(value: JsPlaintext) -> Self {
         match value {
-            JsPlaintext::String(s) => Plaintext::Utf8Str(Some(s)),
+            JsPlaintext::String(s) => Plaintext::Text(Some(s)),
             JsPlaintext::Number(n) => Plaintext::Float(Some(n)),
             JsPlaintext::Boolean(b) => Plaintext::Boolean(Some(b)),
-            JsPlaintext::JsonB(j) => Plaintext::JsonB(Some(j)),
+            JsPlaintext::JsonB(j) => Plaintext::Json(Some(j)),
             JsPlaintext::Date(dt) => Plaintext::Timestamp(Some(dt)),
         }
     }
@@ -40,10 +40,8 @@ impl TryFrom<Plaintext> for JsPlaintext {
 
     fn try_from(value: Plaintext) -> Result<Self, Self::Error> {
         match value {
-            v @ Plaintext::Utf8Str(Some(_)) => {
-                String::try_from_plaintext(v).map(JsPlaintext::String)
-            }
-            v @ Plaintext::JsonB(Some(_)) => {
+            v @ Plaintext::Text(Some(_)) => String::try_from_plaintext(v).map(JsPlaintext::String),
+            v @ Plaintext::Json(Some(_)) => {
                 serde_json::Value::try_from_plaintext(v).map(JsPlaintext::JsonB)
             }
             // Note: BigInt is converted to f64, which may lose precision for integers larger than
@@ -77,10 +75,8 @@ impl JsPlaintext {
         column_type: ColumnType,
     ) -> Result<Plaintext, TypeParseError> {
         match (self, column_type) {
-            // String conversions - Utf8Str, Date, and Timestamp (the latter two parse).
-            (JsPlaintext::String(s), ColumnType::Utf8Str) => {
-                Ok(Plaintext::Utf8Str(Some(s.clone())))
-            }
+            // String conversions - Text, Date, and Timestamp (the latter two parse).
+            (JsPlaintext::String(s), ColumnType::Text) => Ok(Plaintext::Text(Some(s.clone()))),
             (JsPlaintext::String(s), ColumnType::Date) => parse_naive_date(s)
                 .map(|d| Plaintext::NaiveDate(Some(d)))
                 .map_err(|e| TypeParseError(format!("Cannot parse Date: {}", e))),
@@ -111,8 +107,8 @@ impl JsPlaintext {
             // Boolean conversions - only allow to Boolean
             (JsPlaintext::Boolean(b), ColumnType::Boolean) => Ok(Plaintext::Boolean(Some(*b))),
 
-            // JsonB conversions - only allow to JsonB
-            (JsPlaintext::JsonB(j), ColumnType::JsonB) => Ok(Plaintext::JsonB(Some(j.clone()))),
+            // Json conversions - only allow to Json
+            (JsPlaintext::JsonB(j), ColumnType::Json) => Ok(Plaintext::Json(Some(j.clone()))),
 
             // Date conversions: the value is a full UTC timestamp; cast_as picks
             // the storage form.
@@ -120,9 +116,7 @@ impl JsPlaintext {
                 Ok(Plaintext::NaiveDate(Some(dt.date_naive())))
             }
             (JsPlaintext::Date(dt), ColumnType::Timestamp) => Ok(Plaintext::Timestamp(Some(*dt))),
-            (JsPlaintext::Date(dt), ColumnType::Utf8Str) => {
-                Ok(Plaintext::Utf8Str(Some(dt.to_rfc3339())))
-            }
+            (JsPlaintext::Date(dt), ColumnType::Text) => Ok(Plaintext::Text(Some(dt.to_rfc3339()))),
 
             // All other conversions are not allowed - provide helpful error message
             (js_type, col_type) => {
@@ -197,7 +191,7 @@ mod tests {
         fn test_string(s: String) {
             let js_string = JsPlaintext::String(s.clone());
             let plaintext_string: Plaintext = js_string.into();
-            assert_eq!(plaintext_string, Plaintext::Utf8Str(Some(s)));
+            assert_eq!(plaintext_string, Plaintext::Text(Some(s)));
         }
 
         #[quickcheck]
@@ -224,7 +218,7 @@ mod tests {
             let plaintext_jsonb: Plaintext = js_jsonb.into();
             assert_eq!(
                 plaintext_jsonb,
-                Plaintext::JsonB(Some(serde_json::json!({"key": "value"})))
+                Plaintext::Json(Some(serde_json::json!({"key": "value"})))
             );
         }
 
@@ -246,7 +240,7 @@ mod tests {
 
         #[quickcheck]
         fn test_utf8str(s: String) {
-            let plaintext_string = Plaintext::Utf8Str(Some(s.clone()));
+            let plaintext_string = Plaintext::Text(Some(s.clone()));
             let js_string: JsPlaintext = plaintext_string.try_into().unwrap();
             assert_eq!(js_string, JsPlaintext::String(s));
         }
@@ -271,7 +265,7 @@ mod tests {
 
         #[test]
         fn test_jsonb() {
-            let plaintext_jsonb = Plaintext::JsonB(Some(serde_json::json!({"key": "value"})));
+            let plaintext_jsonb = Plaintext::Json(Some(serde_json::json!({"key": "value"})));
             let js_jsonb: JsPlaintext = plaintext_jsonb.try_into().unwrap();
             assert_eq!(
                 js_jsonb,
@@ -327,10 +321,8 @@ mod tests {
         #[test]
         fn test_string_to_utf8str() {
             let js_string = JsPlaintext::String("hello".to_string());
-            let result = js_string
-                .to_plaintext_with_type(ColumnType::Utf8Str)
-                .unwrap();
-            assert_eq!(result, Plaintext::Utf8Str(Some("hello".to_string())));
+            let result = js_string.to_plaintext_with_type(ColumnType::Text).unwrap();
+            assert_eq!(result, Plaintext::Text(Some("hello".to_string())));
         }
 
         #[test]
@@ -410,7 +402,7 @@ mod tests {
         #[test]
         fn test_boolean_to_string_fails() {
             let js_bool = JsPlaintext::Boolean(true);
-            let result = js_bool.to_plaintext_with_type(ColumnType::Utf8Str);
+            let result = js_bool.to_plaintext_with_type(ColumnType::Text);
             assert!(result.is_err());
             assert!(result.unwrap_err().0.contains("Cannot convert"));
         }
@@ -419,15 +411,15 @@ mod tests {
         fn test_jsonb_to_jsonb() {
             let json_value = serde_json::json!({"key": "value"});
             let js_jsonb = JsPlaintext::JsonB(json_value.clone());
-            let result = js_jsonb.to_plaintext_with_type(ColumnType::JsonB).unwrap();
-            assert_eq!(result, Plaintext::JsonB(Some(json_value)));
+            let result = js_jsonb.to_plaintext_with_type(ColumnType::Json).unwrap();
+            assert_eq!(result, Plaintext::Json(Some(json_value)));
         }
 
         #[test]
         fn test_jsonb_to_string_fails() {
             let json_value = serde_json::json!({"key": "value"});
             let js_jsonb = JsPlaintext::JsonB(json_value);
-            let result = js_jsonb.to_plaintext_with_type(ColumnType::Utf8Str);
+            let result = js_jsonb.to_plaintext_with_type(ColumnType::Text);
             assert!(result.is_err());
             assert!(result.unwrap_err().0.contains("Cannot convert"));
         }
@@ -527,12 +519,12 @@ mod tests {
         fn test_date_value_to_string_column_serializes_rfc3339() {
             let t = sample_dt();
             let js = JsPlaintext::Date(t);
-            let result = js.to_plaintext_with_type(ColumnType::Utf8Str).unwrap();
-            if let Plaintext::Utf8Str(Some(ref s)) = result {
+            let result = js.to_plaintext_with_type(ColumnType::Text).unwrap();
+            if let Plaintext::Text(Some(ref s)) = result {
                 let parsed = DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc);
                 assert_eq!(parsed, t);
             } else {
-                panic!("Expected Plaintext::Utf8Str");
+                panic!("Expected Plaintext::Text");
             }
         }
 

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -514,6 +514,7 @@ fn index_type_description(index_type: &str) -> &'static str {
     match index_type {
         "ste_vec" => "JSON path and containment queries",
         "ore" => "range comparisons (<, >, <=, >=)",
+        "ope" => "range comparisons (<, >, <=, >=)",
         "match" => "full-text search queries",
         "unique" => "exact match queries",
         _ => "unknown query type",
@@ -529,6 +530,7 @@ fn format_available_indexes(column_config: &ColumnConfig) -> String {
             IndexType::SteVec { .. } => "ste_vec",
             IndexType::Match { .. } => "match",
             IndexType::Ore => "ore",
+            IndexType::Ope => "ope",
             IndexType::Unique { .. } => "unique",
         })
         .collect();
@@ -555,6 +557,7 @@ fn find_index_for_type<'a>(
                 (IndexType::SteVec { .. }, "ste_vec")
                     | (IndexType::Match { .. }, "match")
                     | (IndexType::Ore, "ore")
+                    | (IndexType::Ope, "ope")
                     | (IndexType::Unique { .. }, "unique")
             )
         })
@@ -604,7 +607,7 @@ enum InferredQueryMode {
 /// - SteVecTerm: Always JSON (fragment to match with @>) → StoreMode (produces sv array)
 /// - Default: For SteVec indexes, infers from plaintext type:
 ///   - String → QueryMode with SteVecSelector (path queries)
-///   - JsonB (Object/Array) → StoreMode (containment queries need sv array)
+///   - Json (Object/Array) → StoreMode (containment queries need sv array)
 ///   - Other indexes use column's cast_type and QueryMode with Default
 fn to_query_plaintext(
     js_plaintext: &JsPlaintext,
@@ -621,8 +624,8 @@ fn to_query_plaintext(
             if let JsPlaintext::String(path) = js_plaintext {
                 validate_json_path(path)?;
             }
-            // Force Utf8Str conversion regardless of column type
-            let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Utf8Str)?;
+            // Force Text conversion regardless of column type
+            let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Text)?;
             Ok((
                 plaintext,
                 InferredQueryMode::QueryMode(QueryOp::SteVecSelector),
@@ -669,7 +672,7 @@ fn to_query_plaintext(
                 }
             }
             // Use Store mode to produce sv array for containment matching
-            let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::JsonB)?;
+            let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Json)?;
             Ok((plaintext, InferredQueryMode::StoreMode))
         }
         QueryOp::Default => {
@@ -679,7 +682,7 @@ fn to_query_plaintext(
                     JsPlaintext::String(path) => {
                         // String → selector (path queries like "$.user.email")
                         validate_json_path(path)?;
-                        let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Utf8Str)?;
+                        let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Text)?;
                         Ok((
                             plaintext,
                             InferredQueryMode::QueryMode(QueryOp::SteVecSelector),
@@ -688,7 +691,7 @@ fn to_query_plaintext(
                     JsPlaintext::JsonB(_) => {
                         // Object/Array → Store mode for containment queries
                         // This produces sv array needed for @> operator matching
-                        let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::JsonB)?;
+                        let plaintext = js_plaintext.to_plaintext_with_type(ColumnType::Json)?;
                         Ok((plaintext, InferredQueryMode::StoreMode))
                     }
                     JsPlaintext::Number(n) => Err(Error::InvalidQueryInput {
@@ -823,6 +826,7 @@ async fn encrypt(
         service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
+        decryption_policy: None,
     };
 
     let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
@@ -894,6 +898,7 @@ async fn encrypt_bulk(
             service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
+            decryption_policy: None,
         };
 
         let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
@@ -964,6 +969,7 @@ async fn encrypt_query(
         service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
+        decryption_policy: None,
     };
 
     let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
@@ -1045,6 +1051,7 @@ async fn encrypt_query_bulk(
             service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
+            decryption_policy: None,
         };
 
         let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
@@ -1425,7 +1432,7 @@ mod tests {
         fn make_column_config_with_indexes(indexes: Vec<Index>) -> ColumnConfig {
             ColumnConfig {
                 name: "test_column".to_string(),
-                cast_type: cipherstash_client::schema::column::ColumnType::Utf8Str,
+                cast_type: cipherstash_client::schema::column::ColumnType::Text,
                 indexes,
                 in_place: false,
                 mode: cipherstash_client::schema::column::ColumnMode::Encrypted,
@@ -1562,14 +1569,14 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // String on SteVec should infer QueryMode with SteVecSelector
             assert!(matches!(
                 result,
                 Ok((
-                    Plaintext::Utf8Str(Some(_)),
+                    Plaintext::Text(Some(_)),
                     InferredQueryMode::QueryMode(QueryOp::SteVecSelector)
                 ))
             ));
@@ -1588,13 +1595,13 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Object on SteVec should infer StoreMode (produces sv array for containment)
             assert!(matches!(
                 result,
-                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+                Ok((Plaintext::Json(Some(_)), InferredQueryMode::StoreMode))
             ));
         }
 
@@ -1611,13 +1618,13 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Array on SteVec should infer StoreMode (produces sv array for containment)
             assert!(matches!(
                 result,
-                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+                Ok((Plaintext::Json(Some(_)), InferredQueryMode::StoreMode))
             ));
         }
 
@@ -1634,7 +1641,7 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Numbers should return error for SteVec queries
@@ -1660,7 +1667,7 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Booleans should return error for SteVec queries
@@ -1680,14 +1687,14 @@ mod tests {
                 &js_plaintext,
                 QueryOp::SteVecSelector,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Explicit SteVecSelector should use QueryMode
             assert!(matches!(
                 result,
                 Ok((
-                    Plaintext::Utf8Str(Some(_)),
+                    Plaintext::Text(Some(_)),
                     InferredQueryMode::QueryMode(QueryOp::SteVecSelector)
                 ))
             ));
@@ -1706,13 +1713,13 @@ mod tests {
                 &js_plaintext,
                 QueryOp::SteVecTerm,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             // Explicit SteVecTerm uses StoreMode to produce sv array for containment
             assert!(matches!(
                 result,
-                Ok((Plaintext::JsonB(Some(_)), InferredQueryMode::StoreMode))
+                Ok((Plaintext::Json(Some(_)), InferredQueryMode::StoreMode))
             ));
         }
 
@@ -1731,14 +1738,14 @@ mod tests {
                 &js_plaintext,
                 QueryOp::Default,
                 &index_type,
-                ColumnType::Utf8Str,
+                ColumnType::Text,
             );
 
             // Non-SteVec with Default should use column type and QueryMode with Default
             assert!(matches!(
                 result,
                 Ok((
-                    Plaintext::Utf8Str(Some(_)),
+                    Plaintext::Text(Some(_)),
                     InferredQueryMode::QueryMode(QueryOp::Default)
                 ))
             ));
@@ -1757,7 +1764,7 @@ mod tests {
                 &js_plaintext,
                 QueryOp::SteVecTerm,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             assert!(result.is_err());
@@ -1795,7 +1802,7 @@ mod tests {
                 &js_plaintext,
                 QueryOp::SteVecSelector,
                 &index_type,
-                ColumnType::JsonB,
+                ColumnType::Json,
             );
 
             assert!(result.is_err());


### PR DESCRIPTION
Bump cipherstash-client, cts-common, and stack-profile from 0.34.1-alpha.2 to 0.34.1-alpha.4 and adapt protect-ffi to the breaking API changes:

- ColumnType::Utf8Str -> ColumnType::Text, ColumnType::JsonB -> ColumnType::Json
- Plaintext::Utf8Str -> Plaintext::Text, Plaintext::JsonB -> Plaintext::Json
- EqlEncryptOpts gained a required decryption_policy field
- IndexType gained an Ope variant; handle it alongside Ore in the index-name helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for OPE (Order Preserving Encryption) index type recognition in query and index operations

* **Improvements**
  * Enhanced encryption configuration and plaintext data handling for improved consistency across encryption operations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/protectjs-ffi/pull/86)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->