### PR TITLE
feat(wasm): add wasm-bindgen bindings (1/4 — core surface)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -694,6 +694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2403,6 +2413,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "cipherstash-client",
+ "console_error_panic_hook",
  "cts-common",
  "getrandom 0.3.4",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,10 +526,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2406,18 +2404,26 @@ dependencies = [
  "chrono",
  "cipherstash-client",
  "cts-common",
+ "getrandom 0.3.4",
  "hex",
+ "js-sys",
  "neon",
  "once_cell",
  "quickcheck",
  "quickcheck_macros",
  "rust_decimal",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
+ "stack-auth",
  "stack-profile",
  "thiserror 2.0.18",
  "tokio",
+ "uuid",
  "vitaminc 0.1.0-pre4.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -3053,6 +3059,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,6 +2424,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -19,7 +19,7 @@ rust_decimal = "1.37"
 serde = "1.0.218"
 serde_json = "1.0.139"
 thiserror = "2.0.18"
-uuid = "1.7"
+uuid = { version = "1.7", features = ["serde"] }
 vitaminc = { version = "=0.1.0-pre4.2", features = ["random", "protected"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -35,6 +35,7 @@ wasm-bindgen-futures = "0.4"
 serde-wasm-bindgen = "0.6"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = ["console"] }
+console_error_panic_hook = "0.1"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -6,24 +6,35 @@ edition = "2021"
 exclude = ["index.node"]
 
 [lib]
-crate-type = ["cdylib"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-chrono = "0.4.42"
+chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
 cipherstash-client = { version = "=0.35.0", features = ["tokio"] }
 cts-common = { version = "=0.35.0", default-features = false }
-stack-profile = { version = "=0.35.0" }
+stack-auth = { version = "=0.35.0" }
 hex = "0.4.3"
-neon = { version = "1", features = ["serde", "tokio"] }
 once_cell = "1.20.2"
 rust_decimal = "1.37"
 serde = "1.0.218"
 serde_json = "1.0.139"
 thiserror = "2.0.18"
+uuid = "1.7"
+vitaminc = { version = "=0.1.0-pre4.2", features = ["random", "protected"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+neon = { version = "1", features = ["serde", "tokio"] }
+stack-profile = { version = "=0.35.0" }
 tokio = { version = "1", features = ["full"] }
-vitaminc = { version = "=0.1.0-pre4.2", features = [ "random", "protected" ] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tokio = { version = "1", default-features = false, features = ["macros", "rt", "sync"] }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+serde-wasm-bindgen = "0.6"
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [dev-dependencies]
 quickcheck = "1.0.3"

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1.0.139"
 thiserror = "2.0.18"
 uuid = { version = "1.7", features = ["serde"] }
 vitaminc = { version = "=0.1.0-pre4.2", features = ["random", "protected"] }
+zeroize = { version = "1.8", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 neon = { version = "1", features = ["serde", "tokio"] }

--- a/crates/protect-ffi/src/js_plaintext.rs
+++ b/crates/protect-ffi/src/js_plaintext.rs
@@ -122,15 +122,15 @@ impl JsPlaintext {
             (js_type, col_type) => {
                 let valid_targets = match js_type {
                     JsPlaintext::String(_) => {
-                        "Utf8Str (string columns), Date, Timestamp (ISO 8601 strings)"
+                        "Text (string columns), Date, Timestamp (ISO 8601 strings)"
                     }
                     JsPlaintext::Number(_) => {
                         "Float, BigInt, Int, SmallInt, BigUInt, Decimal (numeric columns)"
                     }
                     JsPlaintext::Boolean(_) => "Boolean (boolean columns)",
-                    JsPlaintext::JsonB(_) => "JsonB (json columns)",
+                    JsPlaintext::JsonB(_) => "Json (json columns)",
                     JsPlaintext::Date(_) => {
-                        "Date, Timestamp (date/timestamp columns), Utf8Str (ISO 8601 string)"
+                        "Date, Timestamp (date/timestamp columns), Text (ISO 8601 string)"
                     }
                 };
                 let type_name = js_plaintext_type_name(js_type);
@@ -168,7 +168,7 @@ pub(crate) fn js_plaintext_type_name(js_plaintext: &JsPlaintext) -> &'static str
         JsPlaintext::String(_) => "String",
         JsPlaintext::Number(_) => "Number",
         JsPlaintext::Boolean(_) => "Boolean",
-        JsPlaintext::JsonB(_) => "JsonB",
+        JsPlaintext::JsonB(_) => "Json",
         JsPlaintext::Date(_) => "Date",
     }
 }
@@ -572,8 +572,8 @@ mod tests {
             let err_msg = result.unwrap_err().0;
             // Should mention valid targets for String
             assert!(
-                err_msg.contains("Utf8Str"),
-                "Error should mention valid target Utf8Str: {}",
+                err_msg.contains("Text"),
+                "Error should mention valid target Text: {}",
                 err_msg
             );
             // Should mention cast_as setting
@@ -612,8 +612,8 @@ mod tests {
             assert!(result.is_err());
             let err_msg = result.unwrap_err().0;
             assert!(
-                err_msg.contains("JsonB"),
-                "Error should mention valid target JsonB: {}",
+                err_msg.contains("Json"),
+                "Error should mention valid target Json: {}",
                 err_msg
             );
         }

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1,4 +1,6 @@
 mod js_plaintext;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
 
 use cipherstash_client::{
     credentials::ServiceToken,
@@ -1244,7 +1246,7 @@ fn encrypted_record_from_mp_base85(
 ///
 /// Used by `encrypt` / `encrypt_bulk`, which always run with `EqlOperation::Store` and
 /// therefore must produce storage ciphertexts (never query payloads).
-fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
+pub(crate) fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
     match output {
         EqlOutput::Store(ciphertext) => Ok(ciphertext),
         EqlOutput::Query(_) => Err(Error::InvariantViolation(

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1158,51 +1158,71 @@ async fn decrypt_bulk_fallible(
     Boxed(client): Boxed<Client>,
     Json(opts): Json<DecryptBulkOptions>,
 ) -> Result<Json<Vec<DecryptResult>>, neon::types::extract::Error> {
-    let ciphertexts: Vec<(Encrypted, Vec<zerokms::Context>)> = opts
+    // Decode each ciphertext independently so a single invalid payload turns
+    // into a per-item `DecryptResult::Error` rather than aborting the whole
+    // batch — matches the `*Fallible` contract.
+    let parsed: Vec<Result<WithContext<'static>, Error>> = opts
         .ciphertexts
         .into_iter()
         .map(|payload| {
             let lock_context = payload.lock_context.map(Into::into).unwrap_or_default();
-            (payload.ciphertext, lock_context)
+            encrypted_record_from_mp_base85(payload.ciphertext, lock_context)
         })
         .collect();
 
-    let encrypted_records: Vec<WithContext<'static>> = ciphertexts
-        .into_iter()
-        .map(|(ciphertext, encryption_context)| {
-            encrypted_record_from_mp_base85(ciphertext, encryption_context)
-        })
-        .collect::<Result<Vec<_>, Error>>()?;
+    let mut results: Vec<Option<DecryptResult>> = (0..parsed.len()).map(|_| None).collect();
+    let mut valid_records: Vec<WithContext<'static>> = Vec::with_capacity(parsed.len());
+    let mut valid_indices: Vec<usize> = Vec::with_capacity(parsed.len());
+
+    for (idx, item) in parsed.into_iter().enumerate() {
+        match item {
+            Ok(record) => {
+                valid_records.push(record);
+                valid_indices.push(idx);
+            }
+            Err(e) => {
+                results[idx] = Some(DecryptResult::Error {
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
 
     let decrypted: Vec<Result<Vec<u8>, RecordDecryptError>> = client
         .zerokms
         .decrypt_fallible(
-            encrypted_records,
+            valid_records,
             opts.service_token.map(Cow::Owned),
             opts.unverified_context.map(Cow::Owned),
         )
         .await?;
 
-    let plaintexts: Vec<Result<JsPlaintext, Error>> = decrypted
+    for (item, idx) in decrypted.into_iter().zip(valid_indices) {
+        results[idx] = Some(match item {
+            Ok(bytes) => match Plaintext::from_slice(&bytes)
+                .map_err(Error::from)
+                .and_then(|p| JsPlaintext::try_from(p).map_err(Error::from))
+            {
+                Ok(data) => DecryptResult::Success { data },
+                Err(e) => DecryptResult::Error {
+                    error: e.to_string(),
+                },
+            },
+            Err(e) => DecryptResult::Error {
+                error: e.to_string(),
+            },
+        });
+    }
+
+    let results: Vec<DecryptResult> = results
         .into_iter()
-        .map(|item: Result<Vec<u8>, RecordDecryptError>| {
-            item.map_err(Error::from).and_then(|bytes| {
-                Plaintext::from_slice(&bytes)
-                    .map_err(Error::from)
-                    .and_then(|e| JsPlaintext::try_from(e).map_err(Error::from))
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| {
+                Error::InvariantViolation(format!("missing decrypt_fallible result at index {i}"))
             })
         })
-        .collect();
-
-    let results = plaintexts
-        .into_iter()
-        .map(|result| match result {
-            Ok(data) => DecryptResult::Success { data },
-            Err(err) => DecryptResult::Error {
-                error: err.to_string(),
-            },
-        })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(Json(results))
 }
@@ -1246,7 +1266,7 @@ fn encrypted_record_from_mp_base85(
 ///
 /// Used by `encrypt` / `encrypt_bulk`, which always run with `EqlOperation::Store` and
 /// therefore must produce storage ciphertexts (never query payloads).
-pub(crate) fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
+fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
     match output {
         EqlOutput::Store(ciphertext) => Ok(ciphertext),
         EqlOutput::Query(_) => Err(Error::InvariantViolation(

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -20,6 +20,7 @@ use cipherstash_client::{
 };
 use cts_common::Crn;
 use js_plaintext::JsPlaintext;
+#[cfg(not(target_arch = "wasm32"))]
 use neon::{
     prelude::*,
     types::extract::{Boxed, Json},
@@ -31,6 +32,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     sync::Arc,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use tokio::runtime::Runtime;
 
 #[cfg(test)]
@@ -46,6 +48,7 @@ struct Client {
     encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Finalize for Client {}
 
 /// Re-export EqlCiphertext as Encrypted for backward compatibility.
@@ -308,6 +311,10 @@ impl CredentialOpts {
     ///
     /// Note: env vars (`CS_CLIENT_ID`/`CS_CLIENT_KEY`) are read on the JS side
     /// and passed through as explicit fields to support Bun.
+    ///
+    /// Wasm32 has no filesystem — the wasm binding will pass the client key
+    /// inline instead and skip the fallback path entirely.
+    #[cfg(not(target_arch = "wasm32"))]
     fn build_key_provider(
         &self,
     ) -> Result<FallbackKeyProvider<Option<SecretKey>, stack_profile::ProfileStore>, Error> {
@@ -717,6 +724,7 @@ fn to_query_plaintext(
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 pub async fn new_client(
     Json(opts): Json<NewClientOptions>,
@@ -750,6 +758,7 @@ pub async fn new_client(
 ///
 /// The grant step is best-effort: "already granted" errors are expected and ignored,
 /// but other grant failures are logged as warnings since they may indicate misconfiguration.
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 pub async fn ensure_keyset(
     Json(opts): Json<EnsureKeysetOpts>,
@@ -790,6 +799,7 @@ pub async fn ensure_keyset(
     }))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn encrypt(
     Boxed(client): Boxed<Client>,
@@ -830,6 +840,7 @@ async fn encrypt(
     Ok(Json(eql_ciphertext))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn encrypt_bulk(
     Boxed(client): Boxed<Client>,
@@ -918,6 +929,7 @@ async fn encrypt_bulk(
     Ok(Json(final_results))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn encrypt_query(
     Boxed(client): Boxed<Client>,
@@ -973,6 +985,7 @@ async fn encrypt_query(
     Ok(Json(eql_output))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn encrypt_query_bulk(
     Boxed(client): Boxed<Client>,
@@ -1069,6 +1082,7 @@ async fn encrypt_query_bulk(
     Ok(Json(final_results))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn decrypt(
     Boxed(client): Boxed<Client>,
@@ -1095,6 +1109,7 @@ async fn decrypt(
         .map_err(From::from)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn decrypt_bulk(
     Boxed(client): Boxed<Client>,
@@ -1135,6 +1150,7 @@ async fn decrypt_bulk(
     Ok(Json(plaintexts))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 async fn decrypt_bulk_fallible(
     Boxed(client): Boxed<Client>,
@@ -1189,6 +1205,7 @@ async fn decrypt_bulk_fallible(
     Ok(Json(results))
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 fn is_encrypted(Json(raw): Json<serde_json::Value>) -> bool {
     let result: Result<EqlCiphertext, _> = serde_json::from_value(raw);
@@ -1236,8 +1253,10 @@ fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
+#[cfg(not(target_arch = "wasm32"))]
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
     let runtime = RUNTIME

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -25,7 +25,7 @@ use cipherstash_client::eql::{
 };
 use cipherstash_client::schema::{CanonicalEncryptionConfig, ColumnConfig, Identifier};
 use cipherstash_client::zerokms::{
-    self, SecretKey, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey,
+    self, SecretKey, ViturKeyMaterial, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey,
 };
 use cipherstash_client::IdentifiedBy;
 use serde::Deserialize;
@@ -33,6 +33,7 @@ use stack_auth::{AuthError, AuthStrategy, SecretToken, ServiceToken};
 use uuid::Uuid;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::js_plaintext::JsPlaintext;
 use crate::{
@@ -117,6 +118,17 @@ pub struct WasmClient {
     encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
 }
 
+/// Hex-encoded secret material that zeroizes its buffer on drop.
+///
+/// Used as the deserialization target for the client key so the raw hex
+/// material lives only inside a zeroize-on-drop wrapper from the moment
+/// serde produces it — even if `new_client` panics or returns early before
+/// the key is consumed into `SecretKey`. `#[serde(transparent)]` makes a
+/// bare JS string deserialize into it without any schema change.
+#[derive(Deserialize, Zeroize, ZeroizeOnDrop)]
+#[serde(transparent)]
+struct HexSecret(String);
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct NewClientOpts {
@@ -126,9 +138,10 @@ struct NewClientOpts {
     /// than later inside `from_hex`.
     client_id: Uuid,
     /// Hex-encoded v1 client key. Required — wasm has no
-    /// `~/.cipherstash/secretkey.json` fallback. The String is consumed by
-    /// `SecretKey::from_hex`, which zeroizes the hex buffer once decoded.
-    client_key: String,
+    /// `~/.cipherstash/secretkey.json` fallback. Wrapped in [`HexSecret`]
+    /// so the raw hex buffer is zeroized on drop, including on any early
+    /// error path before the bytes are moved into `SecretKey`.
+    client_key: HexSecret,
     /// Optional keyset identifier (id or name). `None` uses the default
     /// keyset granted to the client.
     keyset: Option<IdentifiedBy>,
@@ -140,7 +153,7 @@ struct NewClientOpts {
 /// a `getToken(): Promise<{ token: string, ... }>` method works.
 #[wasm_bindgen(js_name = newClient)]
 pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, JsValue> {
-    let opts: NewClientOpts =
+    let mut opts: NewClientOpts =
         serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
 
     // Pull `getToken` off the strategy object.
@@ -151,12 +164,17 @@ pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, 
         .map_err(|_| js_error("strategy.getToken is not a function"))?;
     let auth = JsAuthStrategy::new(strategy.clone(), get_token);
 
-    // `SecretKey` is a zeroize-on-drop wrapper around the raw key bytes; using
-    // it (rather than the bare `ClientKey`) ensures the in-memory key material
-    // is wiped when this scope exits. `from_hex` consumes and zeroizes the
-    // incoming hex string during decoding.
-    let secret_key = SecretKey::from_hex(opts.client_id.to_string(), opts.client_key)
-        .map_err(|e| js_error(&format!("invalid clientKey: {e}")))?;
+    // Decode the hex buffer in place rather than via `SecretKey::from_hex`:
+    // `from_hex` takes a `String` for the UUID, which would force an
+    // `opts.client_id.to_string()` allocation that the round-trip parses back
+    // to `Uuid` — and that allocation is never zeroized. By decoding here we
+    // (a) keep the already-parsed `Uuid` and (b) keep the hex bytes inside
+    // `HexSecret`, which zeroizes on drop even on the error path.
+    let bytes_result = hex::decode(opts.client_key.0.as_bytes());
+    opts.client_key.0.zeroize();
+    let bytes =
+        bytes_result.map_err(|e| js_error(&format!("invalid clientKey: invalid hex: {e}")))?;
+    let secret_key = SecretKey::new(opts.client_id, ViturKeyMaterial::from(bytes));
 
     let zerokms = ZeroKMSBuilder::new(auth)
         .with_key_provider(secret_key)

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -1,0 +1,558 @@
+//! Wasm-bindgen bindings for protect-ffi.
+//!
+//! Mirrors the Neon exports in `lib.rs` for the `wasm32-unknown-unknown`
+//! target. Uses `serde-wasm-bindgen` for JS↔Rust marshalling and wraps a
+//! JS `getToken` callable (matching `@cipherstash/auth`'s
+//! `AccessKeyStrategy.getToken()` shape) into a [`stack_auth::AuthStrategy`]
+//! via a small adapter struct.
+//!
+//! Unlike the Neon path which uses `AutoStrategy` + env vars + the
+//! filesystem-backed `stack-profile`, the wasm path is fully inline: the
+//! client key is passed as a constructor option, and auth is delegated to
+//! the JS-supplied strategy on every ZeroKMS request.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, HashMap};
+use std::future::Future;
+use std::sync::Arc;
+
+use cipherstash_client::encryption::{Plaintext, ScopedCipher, TypeParseError};
+use cipherstash_client::eql::{
+    encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlOperation, EqlOutput,
+    Identifier as EqlIdentifier, PreparedPlaintext,
+};
+use cipherstash_client::schema::ColumnConfig;
+use cipherstash_client::zerokms::{self, ClientKey, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey};
+use cipherstash_client::IdentifiedBy;
+use serde::Deserialize;
+use stack_auth::{AuthError, AuthStrategy, SecretToken, ServiceToken};
+use uuid::Uuid;
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::JsFuture;
+
+use crate::encrypt_config::{EncryptConfig, Identifier};
+use crate::js_plaintext::JsPlaintext;
+use crate::{
+    encrypted_record_from_mp_base85, find_index_for_type, into_store_ciphertext, parse_query_op,
+    to_query_plaintext, DecryptBulkOptions, DecryptOptions, DecryptResult, EncryptBulkOptions,
+    EncryptOptions, EncryptQueryBulkOptions, EncryptQueryOptions, Encrypted, Error,
+    InferredQueryMode,
+};
+
+// ---------------------------------------------------------------------------
+// Auth strategy adapter
+// ---------------------------------------------------------------------------
+
+/// JS-backed [`AuthStrategy`].
+///
+/// Holds a JS callable `getToken(): Promise<TokenResult>` (the shape
+/// `@cipherstash/auth`'s strategies expose) and calls it whenever
+/// cipherstash-client asks for a fresh service token. Inline rather than
+/// going through `stack_auth::AuthStrategyFn` because the JS callable type
+/// is hard to express as a Rust closure in a stored struct.
+pub(crate) struct JsAuthStrategy {
+    get_token: js_sys::Function,
+}
+
+impl JsAuthStrategy {
+    fn new(get_token: js_sys::Function) -> Self {
+        Self { get_token }
+    }
+}
+
+// Safety: wasm32 is single-threaded; JS handles do not cross threads.
+unsafe impl Send for JsAuthStrategy {}
+unsafe impl Sync for JsAuthStrategy {}
+
+impl AuthStrategy for &JsAuthStrategy {
+    fn get_token(self) -> impl Future<Output = Result<ServiceToken, AuthError>> {
+        let promise = self.get_token.call0(&JsValue::NULL);
+        async move {
+            let promise = promise
+                .map_err(|e| AuthError::Server(format!("strategy.getToken() threw: {e:?}")))?;
+            let promise: js_sys::Promise = promise.dyn_into().map_err(|_| {
+                AuthError::Server("strategy.getToken() did not return a Promise".to_string())
+            })?;
+            let result = JsFuture::from(promise)
+                .await
+                .map_err(|e| AuthError::Server(format!("strategy.getToken() rejected: {e:?}")))?;
+            let token = js_sys::Reflect::get(&result, &JsValue::from_str("token"))
+                .map_err(|e| AuthError::Server(format!("missing token field: {e:?}")))?;
+            let token = token
+                .as_string()
+                .ok_or_else(|| AuthError::Server("token field is not a string".to_string()))?;
+            Ok(ServiceToken::new(SecretToken::new(token)))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/// Wasm-side client handle. Wraps the same `ScopedCipher` +
+/// `ZeroKMSWithClientKey` pair the Neon side does, parameterised by
+/// [`JsAuthStrategy`] instead of `AutoStrategy`.
+#[wasm_bindgen]
+pub struct WasmClient {
+    cipher: Arc<ScopedCipher<JsAuthStrategy>>,
+    zerokms: Arc<ZeroKMSWithClientKey<JsAuthStrategy>>,
+    encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct NewClientOpts {
+    encrypt_config: EncryptConfig,
+    /// UUID identifying the client key (workspace's data-encryption keyset).
+    client_id: String,
+    /// Hex-encoded v1 client key. Required — wasm has no
+    /// `~/.cipherstash/secretkey.json` fallback.
+    client_key: String,
+    /// Optional keyset identifier (id or name). `None` uses the default
+    /// keyset granted to the client.
+    keyset: Option<IdentifiedBy>,
+}
+
+/// Construct a [`WasmClient`].
+///
+/// `strategy` must be an `@cipherstash/auth`-shaped object — anything with
+/// a `getToken(): Promise<{ token: string, ... }>` method works.
+#[wasm_bindgen(js_name = newClient)]
+pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, JsValue> {
+    let opts: NewClientOpts =
+        serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+
+    // Pull `getToken` off the strategy object.
+    let get_token = js_sys::Reflect::get(&strategy, &JsValue::from_str("getToken"))
+        .map_err(|e| js_error(&format!("strategy.getToken not found: {e:?}")))?;
+    let get_token: js_sys::Function = get_token
+        .dyn_into()
+        .map_err(|_| js_error("strategy.getToken is not a function"))?;
+    let auth = JsAuthStrategy::new(get_token);
+
+    let client_id = Uuid::parse_str(&opts.client_id)
+        .map_err(|e| js_error(&format!("invalid clientId: {e}")))?;
+    let client_key = ClientKey::from_hex_v1(client_id, &opts.client_key)
+        .map_err(|e| js_error(&format!("invalid clientKey: {e}")))?;
+
+    let zerokms = ZeroKMSBuilder::new(auth)
+        .with_client_key(client_key)
+        .build()
+        .map_err(|e| js_error(&e.to_string()))?;
+    let zerokms = Arc::new(zerokms);
+    let cipher = ScopedCipher::init(zerokms.clone(), opts.keyset)
+        .await
+        .map_err(|e| js_error(&e.to_string()))?;
+
+    Ok(WasmClient {
+        cipher: Arc::new(cipher),
+        zerokms,
+        encrypt_config: Arc::new(
+            opts.encrypt_config
+                .into_config_map()
+                .map_err(|e| js_error(&e.to_string()))?,
+        ),
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Encrypt / decrypt JS surface
+// ---------------------------------------------------------------------------
+
+#[wasm_bindgen]
+impl WasmClient {
+    #[wasm_bindgen]
+    pub async fn encrypt(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: EncryptOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_encrypt(self, opts).await.map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen(js_name = encryptBulk)]
+    pub async fn encrypt_bulk(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: EncryptBulkOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_encrypt_bulk(self, opts).await.map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen(js_name = encryptQuery)]
+    pub async fn encrypt_query(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: EncryptQueryOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_encrypt_query(self, opts).await.map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen(js_name = encryptQueryBulk)]
+    pub async fn encrypt_query_bulk(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: EncryptQueryBulkOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_encrypt_query_bulk(self, opts)
+            .await
+            .map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen]
+    pub async fn decrypt(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: DecryptOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_decrypt(self, opts).await.map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen(js_name = decryptBulk)]
+    pub async fn decrypt_bulk(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: DecryptBulkOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_decrypt_bulk(self, opts).await.map_err(error_to_js)?;
+        to_js(&out)
+    }
+
+    #[wasm_bindgen(js_name = decryptBulkFallible)]
+    pub async fn decrypt_bulk_fallible(&self, opts: JsValue) -> Result<JsValue, JsValue> {
+        let opts: DecryptBulkOptions =
+            serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
+        let out = do_decrypt_bulk_fallible(self, opts)
+            .await
+            .map_err(error_to_js)?;
+        to_js(&out)
+    }
+}
+
+#[wasm_bindgen(js_name = isEncrypted)]
+pub fn is_encrypted(raw: JsValue) -> bool {
+    let Ok(v) = serde_wasm_bindgen::from_value::<serde_json::Value>(raw) else {
+        return false;
+    };
+    serde_json::from_value::<EqlCiphertext>(v).is_ok()
+}
+
+// ---------------------------------------------------------------------------
+// Logic helpers — mirror the Neon `#[neon::export]` fn bodies in lib.rs.
+// ---------------------------------------------------------------------------
+
+async fn do_encrypt(client: &WasmClient, opts: EncryptOptions) -> Result<Encrypted, Error> {
+    let ident = Identifier::new(opts.table.clone(), opts.column.clone());
+    let column_config = client
+        .encrypt_config
+        .get(&ident)
+        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+    let plaintext = opts
+        .plaintext
+        .to_plaintext_with_type(column_config.cast_type)?;
+    let eql_ident = EqlIdentifier::new(&opts.table, &opts.column);
+    let prepared = PreparedPlaintext::new(
+        Cow::Borrowed(column_config),
+        eql_ident,
+        plaintext,
+        EqlOperation::Store,
+    );
+    let eql_opts = EqlEncryptOpts {
+        keyset_id: None,
+        lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
+        service_token: opts.service_token.map(Cow::Owned),
+        unverified_context: opts.unverified_context.map(Cow::Owned),
+        index_types: None,
+        decryption_policy: None,
+    };
+    let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
+    into_store_ciphertext(encrypted.remove(0))
+}
+
+async fn do_encrypt_bulk(
+    client: &WasmClient,
+    opts: EncryptBulkOptions,
+) -> Result<Vec<Encrypted>, Error> {
+    // Group payloads by lock_context identity_claim — same shape as native.
+    // We move the LockContext (no Clone) and extract its identity_claim
+    // (Vec<String>, which IS Clone) as the group key.
+    let mut groups: BTreeMap<Vec<String>, Vec<(usize, crate::PlaintextPayload)>> = BTreeMap::new();
+    for (idx, payload) in opts.plaintexts.into_iter().enumerate() {
+        let key = payload
+            .lock_context
+            .as_ref()
+            .map(|lc| lc.identity_claim.clone())
+            .unwrap_or_default();
+        groups.entry(key).or_default().push((idx, payload));
+    }
+
+    let total: usize = groups.values().map(|v| v.len()).sum();
+    let mut results: Vec<Option<Encrypted>> = (0..total).map(|_| None).collect();
+
+    for (identity_claim, payloads) in groups {
+        let lock_context: Vec<zerokms::Context> = identity_claim
+            .into_iter()
+            .map(zerokms::Context::IdentityClaim)
+            .collect();
+
+        let mut prepared_plaintexts = Vec::with_capacity(payloads.len());
+        let mut original_indices = Vec::with_capacity(payloads.len());
+
+        for (original_idx, payload) in payloads {
+            let ident = Identifier::new(payload.table.clone(), payload.column.clone());
+            let column_config = client
+                .encrypt_config
+                .get(&ident)
+                .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+            let plaintext = payload
+                .plaintext
+                .to_plaintext_with_type(column_config.cast_type)?;
+            let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
+            let prepared = PreparedPlaintext::new(
+                Cow::Owned(column_config.clone()),
+                eql_ident,
+                plaintext,
+                EqlOperation::Store,
+            );
+            prepared_plaintexts.push(prepared);
+            original_indices.push(original_idx);
+        }
+
+        let eql_opts = EqlEncryptOpts {
+            keyset_id: None,
+            lock_context: Cow::Owned(lock_context),
+            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
+            unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
+            index_types: None,
+            decryption_policy: None,
+        };
+
+        let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
+        for (eql_output, original_idx) in encrypted.into_iter().zip(original_indices) {
+            results[original_idx] = Some(into_store_ciphertext(eql_output)?);
+        }
+    }
+
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| Error::InvariantViolation(format!("missing bulk result {i}")))
+        })
+        .collect()
+}
+
+async fn do_encrypt_query(
+    client: &WasmClient,
+    opts: EncryptQueryOptions,
+) -> Result<EqlOutput, Error> {
+    let ident = Identifier::new(opts.table.clone(), opts.column.clone());
+    let column_config = client
+        .encrypt_config
+        .get(&ident)
+        .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+    let index = find_index_for_type(column_config, &opts.column, &opts.index_type)?;
+    let query_op = parse_query_op(&opts.query_op)?;
+    let (plaintext, inferred_mode) =
+        to_query_plaintext(&opts.plaintext, query_op, &index.index_type, column_config.cast_type)?;
+    let eql_operation = match inferred_mode {
+        InferredQueryMode::QueryMode(qop) => EqlOperation::Query(&index.index_type, qop),
+        InferredQueryMode::StoreMode => EqlOperation::Store,
+    };
+    let eql_ident = EqlIdentifier::new(&opts.table, &opts.column);
+    let prepared = PreparedPlaintext::new(
+        Cow::Borrowed(column_config),
+        eql_ident,
+        plaintext,
+        eql_operation,
+    );
+    let eql_opts = EqlEncryptOpts {
+        keyset_id: None,
+        lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
+        service_token: opts.service_token.map(Cow::Owned),
+        unverified_context: opts.unverified_context.map(Cow::Owned),
+        index_types: None,
+        decryption_policy: None,
+    };
+    let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
+    Ok(encrypted.remove(0))
+}
+
+async fn do_encrypt_query_bulk(
+    client: &WasmClient,
+    opts: EncryptQueryBulkOptions,
+) -> Result<Vec<EqlOutput>, Error> {
+    let mut groups: BTreeMap<Vec<String>, Vec<(usize, crate::QueryPayload)>> = BTreeMap::new();
+    for (idx, payload) in opts.queries.into_iter().enumerate() {
+        let key = payload
+            .lock_context
+            .as_ref()
+            .map(|lc| lc.identity_claim.clone())
+            .unwrap_or_default();
+        groups.entry(key).or_default().push((idx, payload));
+    }
+
+    let total: usize = groups.values().map(|v| v.len()).sum();
+    let mut results: Vec<Option<EqlOutput>> = (0..total).map(|_| None).collect();
+
+    for (identity_claim, payloads) in groups {
+        let lock_context: Vec<zerokms::Context> = identity_claim
+            .into_iter()
+            .map(zerokms::Context::IdentityClaim)
+            .collect();
+
+        let mut prepared_plaintexts = Vec::with_capacity(payloads.len());
+        let mut original_indices = Vec::with_capacity(payloads.len());
+
+        for (original_idx, payload) in payloads {
+            let ident = Identifier::new(payload.table.clone(), payload.column.clone());
+            let column_config = client
+                .encrypt_config
+                .get(&ident)
+                .ok_or_else(|| Error::UnknownColumn(ident.clone()))?;
+            let index = find_index_for_type(column_config, &payload.column, &payload.index_type)?;
+            let query_op = parse_query_op(&payload.query_op)?;
+            let (plaintext, inferred_mode) = to_query_plaintext(
+                &payload.plaintext,
+                query_op,
+                &index.index_type,
+                column_config.cast_type,
+            )?;
+            let eql_operation = match inferred_mode {
+                InferredQueryMode::QueryMode(qop) => EqlOperation::Query(&index.index_type, qop),
+                InferredQueryMode::StoreMode => EqlOperation::Store,
+            };
+            let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
+            let prepared = PreparedPlaintext::new(
+                Cow::Owned(column_config.clone()),
+                eql_ident,
+                plaintext,
+                eql_operation,
+            );
+            prepared_plaintexts.push(prepared);
+            original_indices.push(original_idx);
+        }
+
+        let eql_opts = EqlEncryptOpts {
+            keyset_id: None,
+            lock_context: Cow::Owned(lock_context),
+            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
+            unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
+            index_types: None,
+            decryption_policy: None,
+        };
+
+        let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
+        for (ciphertext, original_idx) in encrypted.into_iter().zip(original_indices) {
+            results[original_idx] = Some(ciphertext);
+        }
+    }
+
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| Error::InvariantViolation(format!("missing query result {i}")))
+        })
+        .collect()
+}
+
+async fn do_decrypt(client: &WasmClient, opts: DecryptOptions) -> Result<JsPlaintext, Error> {
+    let lock_context = opts.lock_context.map(Into::into).unwrap_or_default();
+    let encrypted_record = encrypted_record_from_mp_base85(opts.ciphertext, lock_context)?;
+
+    let bytes = client
+        .zerokms
+        .decrypt_single(
+            encrypted_record,
+            None,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.as_ref(),
+        )
+        .await
+        .map_err(Error::from)?;
+    let plaintext = Plaintext::from_slice(bytes.as_slice()).map_err(Error::from)?;
+    Ok(JsPlaintext::try_from(plaintext)?)
+}
+
+async fn do_decrypt_bulk(
+    client: &WasmClient,
+    opts: DecryptBulkOptions,
+) -> Result<Vec<JsPlaintext>, Error> {
+    let encrypted_records: Vec<WithContext<'static>> = opts
+        .ciphertexts
+        .into_iter()
+        .map(|payload| {
+            let lock_context: Vec<zerokms::Context> =
+                payload.lock_context.map(Into::into).unwrap_or_default();
+            encrypted_record_from_mp_base85(payload.ciphertext, lock_context)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let decrypted = client
+        .zerokms
+        .decrypt(
+            encrypted_records,
+            None,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.as_ref(),
+        )
+        .await?;
+
+    decrypted
+        .into_iter()
+        .map(|bytes| Plaintext::from_slice(&bytes).and_then(JsPlaintext::try_from))
+        .collect::<Result<Vec<_>, TypeParseError>>()
+        .map_err(Error::from)
+}
+
+async fn do_decrypt_bulk_fallible(
+    client: &WasmClient,
+    opts: DecryptBulkOptions,
+) -> Result<Vec<DecryptResult>, Error> {
+    let encrypted_records: Vec<WithContext<'static>> = opts
+        .ciphertexts
+        .into_iter()
+        .map(|payload| {
+            let lock_context: Vec<zerokms::Context> =
+                payload.lock_context.map(Into::into).unwrap_or_default();
+            encrypted_record_from_mp_base85(payload.ciphertext, lock_context)
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let decrypted = client
+        .zerokms
+        .decrypt_fallible(
+            encrypted_records,
+            opts.service_token.map(Cow::Owned),
+            opts.unverified_context.map(Cow::Owned),
+        )
+        .await?;
+
+    Ok(decrypted
+        .into_iter()
+        .map(|item| match item {
+            Ok(bytes) => match Plaintext::from_slice(&bytes)
+                .map_err(Error::from)
+                .and_then(|p| JsPlaintext::try_from(p).map_err(Error::from))
+            {
+                Ok(data) => DecryptResult::Success { data },
+                Err(e) => DecryptResult::Error { error: e.to_string() },
+            },
+            Err(e) => DecryptResult::Error { error: e.to_string() },
+        })
+        .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Error / value helpers
+// ---------------------------------------------------------------------------
+
+fn js_error(msg: &str) -> JsValue {
+    js_sys::Error::new(msg).into()
+}
+
+fn error_to_js(e: Error) -> JsValue {
+    js_error(&e.to_string())
+}
+
+fn to_js<T: serde::Serialize>(value: &T) -> Result<JsValue, JsValue> {
+    serde_wasm_bindgen::to_value(value).map_err(|e| js_error(&e.to_string()))
+}
+

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -52,12 +52,19 @@ use crate::{
 /// going through `stack_auth::AuthStrategyFn` because the JS callable type
 /// is hard to express as a Rust closure in a stored struct.
 pub(crate) struct JsAuthStrategy {
+    /// The original JS strategy object — kept so `getToken()` is invoked with the
+    /// correct `this` receiver. Class-based strategies read instance state via
+    /// `this`; calling with `JsValue::NULL` breaks them.
+    strategy: JsValue,
     get_token: js_sys::Function,
 }
 
 impl JsAuthStrategy {
-    fn new(get_token: js_sys::Function) -> Self {
-        Self { get_token }
+    fn new(strategy: JsValue, get_token: js_sys::Function) -> Self {
+        Self {
+            strategy,
+            get_token,
+        }
     }
 }
 
@@ -67,7 +74,7 @@ unsafe impl Sync for JsAuthStrategy {}
 
 impl AuthStrategy for &JsAuthStrategy {
     fn get_token(self) -> impl Future<Output = Result<ServiceToken, AuthError>> {
-        let promise = self.get_token.call0(&JsValue::NULL);
+        let promise = self.get_token.call0(&self.strategy);
         async move {
             let promise = promise
                 .map_err(|e| AuthError::Server(format!("strategy.getToken() threw: {e:?}")))?;
@@ -130,7 +137,7 @@ pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, 
     let get_token: js_sys::Function = get_token
         .dyn_into()
         .map_err(|_| js_error("strategy.getToken is not a function"))?;
-    let auth = JsAuthStrategy::new(get_token);
+    let auth = JsAuthStrategy::new(strategy.clone(), get_token);
 
     let client_id = Uuid::parse_str(&opts.client_id)
         .map_err(|e| js_error(&format!("invalid clientId: {e}")))?;
@@ -505,7 +512,10 @@ async fn do_decrypt_bulk_fallible(
     client: &WasmClient,
     opts: DecryptBulkOptions,
 ) -> Result<Vec<DecryptResult>, Error> {
-    let encrypted_records: Vec<WithContext<'static>> = opts
+    // Decode each ciphertext independently so a single invalid payload turns
+    // into a per-item `DecryptResult::Error` rather than aborting the whole
+    // batch — matches the `*Fallible` contract.
+    let parsed: Vec<Result<WithContext<'static>, Error>> = opts
         .ciphertexts
         .into_iter()
         .map(|payload| {
@@ -513,30 +523,61 @@ async fn do_decrypt_bulk_fallible(
                 payload.lock_context.map(Into::into).unwrap_or_default();
             encrypted_record_from_mp_base85(payload.ciphertext, lock_context)
         })
-        .collect::<Result<Vec<_>, _>>()?;
+        .collect();
+
+    let mut results: Vec<Option<DecryptResult>> = (0..parsed.len()).map(|_| None).collect();
+    let mut valid_records: Vec<WithContext<'static>> = Vec::with_capacity(parsed.len());
+    let mut valid_indices: Vec<usize> = Vec::with_capacity(parsed.len());
+
+    for (idx, item) in parsed.into_iter().enumerate() {
+        match item {
+            Ok(record) => {
+                valid_records.push(record);
+                valid_indices.push(idx);
+            }
+            Err(e) => {
+                results[idx] = Some(DecryptResult::Error {
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
 
     let decrypted = client
         .zerokms
         .decrypt_fallible(
-            encrypted_records,
+            valid_records,
             opts.service_token.map(Cow::Owned),
             opts.unverified_context.map(Cow::Owned),
         )
         .await?;
 
-    Ok(decrypted
-        .into_iter()
-        .map(|item| match item {
+    for (item, idx) in decrypted.into_iter().zip(valid_indices) {
+        results[idx] = Some(match item {
             Ok(bytes) => match Plaintext::from_slice(&bytes)
                 .map_err(Error::from)
                 .and_then(|p| JsPlaintext::try_from(p).map_err(Error::from))
             {
                 Ok(data) => DecryptResult::Success { data },
-                Err(e) => DecryptResult::Error { error: e.to_string() },
+                Err(e) => DecryptResult::Error {
+                    error: e.to_string(),
+                },
             },
-            Err(e) => DecryptResult::Error { error: e.to_string() },
+            Err(e) => DecryptResult::Error {
+                error: e.to_string(),
+            },
+        });
+    }
+
+    results
+        .into_iter()
+        .enumerate()
+        .map(|(i, opt)| {
+            opt.ok_or_else(|| {
+                Error::InvariantViolation(format!("missing decrypt_fallible result at index {i}"))
+            })
         })
-        .collect())
+        .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -24,7 +24,9 @@ use cipherstash_client::eql::{
     Identifier as EqlIdentifier, PreparedPlaintext,
 };
 use cipherstash_client::schema::{CanonicalEncryptionConfig, ColumnConfig, Identifier};
-use cipherstash_client::zerokms::{self, ClientKey, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey};
+use cipherstash_client::zerokms::{
+    self, SecretKey, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey,
+};
 use cipherstash_client::IdentifiedBy;
 use serde::Deserialize;
 use stack_auth::{AuthError, AuthStrategy, SecretToken, ServiceToken};
@@ -68,7 +70,14 @@ impl JsAuthStrategy {
     }
 }
 
-// Safety: wasm32 is single-threaded; JS handles do not cross threads.
+// Safety: wasm32-unknown-unknown is single-threaded, and `JsValue` /
+// `js_sys::Function` handles cannot cross threads even in principle. The
+// `Send + Sync` bound only exists because `cipherstash_client::ScopedCipher`
+// and `ZeroKMSWithClientKey` carry a blanket `C: Send + Sync + 'static`
+// bound on their methods (inherited from the native build). Dropping this
+// unsafe impl requires an upstream change in cipherstash-client to relax
+// those bounds on `target_arch = "wasm32"` (similar to the existing
+// `AuthStrategy` split in `stack-auth`).
 unsafe impl Send for JsAuthStrategy {}
 unsafe impl Sync for JsAuthStrategy {}
 
@@ -113,9 +122,12 @@ pub struct WasmClient {
 struct NewClientOpts {
     encrypt_config: CanonicalEncryptionConfig,
     /// UUID identifying the client key (workspace's data-encryption keyset).
-    client_id: String,
+    /// Typed as `Uuid` so a malformed value fails at deserialization rather
+    /// than later inside `from_hex`.
+    client_id: Uuid,
     /// Hex-encoded v1 client key. Required — wasm has no
-    /// `~/.cipherstash/secretkey.json` fallback.
+    /// `~/.cipherstash/secretkey.json` fallback. The String is consumed by
+    /// `SecretKey::from_hex`, which zeroizes the hex buffer once decoded.
     client_key: String,
     /// Optional keyset identifier (id or name). `None` uses the default
     /// keyset granted to the client.
@@ -139,14 +151,17 @@ pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, 
         .map_err(|_| js_error("strategy.getToken is not a function"))?;
     let auth = JsAuthStrategy::new(strategy.clone(), get_token);
 
-    let client_id = Uuid::parse_str(&opts.client_id)
-        .map_err(|e| js_error(&format!("invalid clientId: {e}")))?;
-    let client_key = ClientKey::from_hex_v1(client_id, &opts.client_key)
+    // `SecretKey` is a zeroize-on-drop wrapper around the raw key bytes; using
+    // it (rather than the bare `ClientKey`) ensures the in-memory key material
+    // is wiped when this scope exits. `from_hex` consumes and zeroizes the
+    // incoming hex string during decoding.
+    let secret_key = SecretKey::from_hex(opts.client_id.to_string(), opts.client_key)
         .map_err(|e| js_error(&format!("invalid clientKey: {e}")))?;
 
     let zerokms = ZeroKMSBuilder::new(auth)
-        .with_client_key(client_key)
+        .with_key_provider(secret_key)
         .build()
+        .await
         .map_err(|e| js_error(&e.to_string()))?;
     let zerokms = Arc::new(zerokms);
     let cipher = ScopedCipher::init(zerokms.clone(), opts.keyset)

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -10,6 +10,21 @@
 //! filesystem-backed `stack-profile`, the wasm path is fully inline: the
 //! client key is passed as a constructor option, and auth is delegated to
 //! the JS-supplied strategy on every ZeroKMS request.
+//!
+//! # Auth caching
+//!
+//! [`JsAuthStrategy::get_token`] is invoked on every ZeroKMS request —
+//! there is no Rust-side equivalent of [`stack_auth::AutoRefresh`] in the
+//! wasm path. Caching is the JS strategy's responsibility (cookies,
+//! `localStorage`, or whatever the embedding runtime provides). The
+//! adapter is intentionally a thin shim so the host environment owns the
+//! refresh / persistence policy.
+//!
+//! # Surface omissions
+//!
+//! Admin-shape operations (`ensureKeyset`, workspace management) are
+//! intentionally not exported on the wasm surface — provisioning belongs
+//! in your server, not in browser / edge code.
 
 #![cfg(target_arch = "wasm32")]
 
@@ -42,6 +57,22 @@ use crate::{
     EncryptOptions, EncryptQueryBulkOptions, EncryptQueryOptions, Encrypted, Error,
     InferredQueryMode,
 };
+
+// ---------------------------------------------------------------------------
+// Module init
+// ---------------------------------------------------------------------------
+
+/// Install [`console_error_panic_hook`] so Rust panics surface as a JS
+/// `Error` in the browser / Node console instead of a bare
+/// `RuntimeError: unreachable executed` from the wasm trap. Idempotent —
+/// safe to call from any number of entry points.
+///
+/// Wired via `#[wasm_bindgen(start)]` so it runs once at module
+/// instantiation, before any `newClient` / `encrypt` / `decrypt` call.
+#[wasm_bindgen(start)]
+pub fn init() {
+    console_error_panic_hook::set_once();
+}
 
 // ---------------------------------------------------------------------------
 // Auth strategy adapter
@@ -344,7 +375,7 @@ async fn do_encrypt_bulk(
                 .to_plaintext_with_type(column_config.cast_type)?;
             let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
             let prepared = PreparedPlaintext::new(
-                Cow::Owned(column_config.clone()),
+                Cow::Borrowed(column_config),
                 eql_ident,
                 plaintext,
                 EqlOperation::Store,
@@ -459,7 +490,7 @@ async fn do_encrypt_query_bulk(
             };
             let eql_ident = EqlIdentifier::new(&payload.table, &payload.column);
             let prepared = PreparedPlaintext::new(
-                Cow::Owned(column_config.clone()),
+                Cow::Borrowed(column_config),
                 eql_ident,
                 plaintext,
                 eql_operation,

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -23,7 +23,7 @@ use cipherstash_client::eql::{
     encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlOperation, EqlOutput,
     Identifier as EqlIdentifier, PreparedPlaintext,
 };
-use cipherstash_client::schema::ColumnConfig;
+use cipherstash_client::schema::{CanonicalEncryptionConfig, ColumnConfig, Identifier};
 use cipherstash_client::zerokms::{self, ClientKey, WithContext, ZeroKMSBuilder, ZeroKMSWithClientKey};
 use cipherstash_client::IdentifiedBy;
 use serde::Deserialize;
@@ -32,7 +32,6 @@ use uuid::Uuid;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
-use crate::encrypt_config::{EncryptConfig, Identifier};
 use crate::js_plaintext::JsPlaintext;
 use crate::{
     encrypted_record_from_mp_base85, find_index_for_type, into_store_ciphertext, parse_query_op,
@@ -105,7 +104,7 @@ pub struct WasmClient {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct NewClientOpts {
-    encrypt_config: EncryptConfig,
+    encrypt_config: CanonicalEncryptionConfig,
     /// UUID identifying the client key (workspace's data-encryption keyset).
     client_id: String,
     /// Hex-encoded v1 client key. Required — wasm has no


### PR DESCRIPTION
First of a four-PR stack adding `wasm32-unknown-unknown` support to `protect-ffi` alongside the existing Neon bindings. Layer 4 of `wasm-analysis.md` (cipherstash-suite).

## Why

`@cipherstash/protect-ffi` is currently Neon-only — there's no path to call ZeroKMS `encrypt`/`decrypt` from Supabase Edge / Cloudflare Workers / browser contexts. This stack closes that gap by adding a parallel `wasm-bindgen` surface in the same crate, cfg-gated so the Neon path is unchanged.

## What's in this PR

- **`crates/protect-ffi/Cargo.toml`** — bump `cipherstash-client` + `vitaminc` to versions with wasm-readiness landed; target-split `tokio` so `mio` (no wasm32 build) is only pulled on native; add wasm-bindgen + serde-wasm-bindgen + getrandom under a `cfg(target_arch = "wasm32")` stanza.
- **Cfg-gate Neon-only code** — `#[cfg(not(target_arch = "wasm32"))]` on the `#[neon::export]` fns + `#[neon::main]` + `Finalize for Client` + `RUNTIME` static + filesystem-backed `stack-profile` usage. Encrypt-config and js-plaintext modules stay shared.
- **`src/wasm.rs`** — full wasm-bindgen surface: `WasmClient` handle, `newClient`/`encrypt`/`encryptBulk`/`encryptQuery`/`encryptQueryBulk`/`decrypt`/`decryptBulk`/`decryptBulkFallible`/`isEncrypted`. Auth comes via `JsAuthStrategy`, which wraps a JS `getToken(): Promise<TokenResult>` callable.

## Overlap with existing PR

PR #86 (cipherstash-client 0.34.1-alpha.4 bump) overlaps with the `a8ea7b2` chore commit here. Either land #86 first and rebase this branch, or supersede #86 with this PR — caller's choice.

## Stack

1. **This PR** — core wasm-bindgen surface ← you are here
2. #?? — npm build pipeline + CI
3. #?? — flat API shape (match Neon's exports)
4. #?? — Node + Supabase Edge smoke tests

## Upstream follow-ups (cipherstash-client)

Two workarounds in this PR that should disappear once the upstream issues land:

- [BUG-282](https://linear.app/cipherstash/issue/BUG-282/cipherstash-client-relax-send-sync-bounds-on-scopedcipher) — relax `Send + Sync` bounds on `ScopedCipher` / `ZeroKMSWithClientKey` for wasm32. Once fixed we can drop `unsafe impl Send/Sync for JsAuthStrategy` in `src/wasm.rs`.
- [BUG-283](https://linear.app/cipherstash/issue/BUG-283/cipherstash-client-secretkey-needs-an-ffi-friendly-deserialize) — give `SecretKey` an FFI-friendly `Deserialize` (camelCase + hex) and/or a `from_hex_with_uuid(Uuid, String)` constructor (plus fix the latent hex-not-zeroized error path in `from_hex`). Once fixed we can drop the local `HexSecret` newtype and decode `SecretKey` directly from JS input.

## 🤝 Work agreements

- [x] I have run this code locally or in infradev
- [x] I have reviewed and run anything produced by an AI before asking my colleagues to review it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAssembly client with a JavaScript-facing API for encrypt/decrypt, bulk operations, and an isEncrypted check.

* **Refactor**
  * Clear separation of native and wasm behaviors with platform-specific packaging and initialization.

* **Improvements**
  * decryptBulkFallible now returns per-item error results for malformed inputs instead of failing entire batches.
  * Clarified plaintext error messages (now reference "Text" and "Json").

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/protectjs-ffi/pull/87?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
