### PR TITLE
refactor: upgrade cipherstash-client to 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -545,9 +545,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac2947dd3f7b3ed5625d858f0c1546d015825d460e5145b7aab61c0827648bb5"
+checksum = "0257cff25a25a706af6e190e5209865aae4ddf0b36f81febee7de014b22bcc40"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5631b836b71f0f6dc40aba7bce883d5fcdefe3af645e95307591e70171d1dd62"
+checksum = "d376d237e368e77de53b07bb7309812f45809299063c80b6cc3132f7d8494aed"
 dependencies = [
  "bitflags",
  "serde",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-core"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183754259e12661c7ba3feb23dd38cd852df206964751cce5663bf0b728bf9a1"
+checksum = "ca84ffd8a7b2f0c8c6b04eba600738fea115f5a4ed825035a2f13aa1524085a7"
 dependencies = [
  "getrandom 0.2.17",
  "hmac",
@@ -826,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "cts-common"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4df8c15eecbb0bba2816e986c4b9d7493eb487bfb209f189375d22d3877801"
+checksum = "ae6508011dee61bc36e16615e43cb26a8014c49ebb832e713602f3b0dc15af29"
 dependencies = [
  "arrayvec",
  "base32",
@@ -3237,9 +3237,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stack-auth"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c02b8b228d4f62f108a3d8bc262a09ac76523728b5a710dd3d1b6c8a7e437a9"
+checksum = "c823cc3d88e15478d51694ef56037400bd4ae3e1a9e046071e01d251168cc466"
 dependencies = [
  "aquamarine",
  "base64",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "stack-profile"
-version = "0.34.1-alpha.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7e04cfccdd7bbc62bdde8437d13ed672bef273711a311ecfdbeb946b879ad6"
+checksum = "cfd1be30119d59260f3e932f78fbbfbe3674c151d39e7fcca24d0439e7e31ba8"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4840,9 +4840,9 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61f5c1ecddfe849a1f292e0c28993c3857c026842c3b890ff2e451322b46272f"
+checksum = "04a9411f442b247e7d00c6a07cfbc6d56c12d485cfaf4f7effa001bfb1615296"
 dependencies = [
  "base64",
  "cipherstash-config",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -12,9 +12,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 chrono = "0.4.42"
-cipherstash-client = { version = "=0.34.1-alpha.7", features = ["tokio"] }
-cts-common = { version = "=0.34.1-alpha.7", default-features = false }
-stack-profile = { version = "=0.34.1-alpha.7" }
+cipherstash-client = { version = "=0.35.0", features = ["tokio"] }
+cts-common = { version = "=0.35.0", default-features = false }
+stack-profile = { version = "=0.35.0" }
 hex = "0.4.3"
 neon = { version = "1", features = ["serde", "tokio"] }
 once_cell = "1.20.2"

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -4,7 +4,7 @@ use cipherstash_client::{
     credentials::ServiceToken,
     encryption::{EncryptionError, Plaintext, QueryOp, ScopedCipher, TypeParseError},
     eql::{
-        encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlError, EqlOperation,
+        encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlError, EqlOperation, EqlOutput,
         Identifier as EqlIdentifier, PreparedPlaintext,
     },
     schema::{
@@ -50,10 +50,10 @@ impl Finalize for Client {}
 
 /// Re-export EqlCiphertext as Encrypted for backward compatibility.
 ///
-/// This is a unified structure that contains the identifier, version, and the encrypted body
-/// with all associated cryptographic searchable encrypted metadata (SEM).
-///
-/// Note: The ciphertext field (c) is serialized in MessagePack Base85 format.
+/// `EqlCiphertext` is the EQL v2.3 storage payload — a discriminated enum that is either
+/// a scalar `Encrypted` payload (`k = "ct"`) or a structured `SteVec` payload (`k = "sv"`).
+/// The MessagePack-Base85 ciphertext lives at `c` on the scalar variant, or at `sv[0].c`
+/// for the SteVec variant.
 pub type Encrypted = EqlCiphertext;
 
 /// What type of value was received in a query
@@ -825,7 +825,7 @@ async fn encrypt(
     };
 
     let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
-    let eql_ciphertext = encrypted.remove(0);
+    let eql_ciphertext = into_store_ciphertext(encrypted.remove(0))?;
 
     Ok(Json(eql_ciphertext))
 }
@@ -899,8 +899,8 @@ async fn encrypt_bulk(
         let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
 
         // Place results back in original order
-        for (eql_ciphertext, (original_idx, _ident)) in encrypted.into_iter().zip(payload_data) {
-            results[original_idx] = Some(eql_ciphertext);
+        for (eql_output, (original_idx, _ident)) in encrypted.into_iter().zip(payload_data) {
+            results[original_idx] = Some(into_store_ciphertext(eql_output)?);
         }
     }
 
@@ -922,7 +922,7 @@ async fn encrypt_bulk(
 async fn encrypt_query(
     Boxed(client): Boxed<Client>,
     Json(opts): Json<EncryptQueryOptions>,
-) -> Result<Json<EqlCiphertext>, neon::types::extract::Error> {
+) -> Result<Json<EqlOutput>, neon::types::extract::Error> {
     let ident = Identifier::new(opts.table.clone(), opts.column.clone());
 
     let column_config = client
@@ -968,16 +968,16 @@ async fn encrypt_query(
     };
 
     let mut encrypted = encrypt_eql(client.cipher.clone(), vec![prepared], &eql_opts).await?;
-    let eql_ciphertext = encrypted.remove(0);
+    let eql_output = encrypted.remove(0);
 
-    Ok(Json(eql_ciphertext))
+    Ok(Json(eql_output))
 }
 
 #[neon::export]
 async fn encrypt_query_bulk(
     Boxed(client): Boxed<Client>,
     Json(opts): Json<EncryptQueryBulkOptions>,
-) -> Result<Json<Vec<EqlCiphertext>>, neon::types::extract::Error> {
+) -> Result<Json<Vec<EqlOutput>>, neon::types::extract::Error> {
     // Group payloads by lock_context (same pattern as encrypt_bulk)
     let mut groups: BTreeMap<Vec<String>, Vec<(usize, QueryPayload)>> = BTreeMap::new();
 
@@ -991,7 +991,7 @@ async fn encrypt_query_bulk(
     }
 
     let total_count: usize = groups.values().map(|g| g.len()).sum();
-    let mut results: Vec<Option<EqlCiphertext>> = (0..total_count).map(|_| None).collect();
+    let mut results: Vec<Option<EqlOutput>> = (0..total_count).map(|_| None).collect();
 
     for (lock_context_claims, payloads) in groups {
         let lock_context: Vec<zerokms::Context> = lock_context_claims
@@ -1051,12 +1051,12 @@ async fn encrypt_query_bulk(
 
         let encrypted = encrypt_eql(client.cipher.clone(), prepared_plaintexts, &eql_opts).await?;
 
-        for (eql_ciphertext, original_idx) in encrypted.into_iter().zip(original_indices) {
-            results[original_idx] = Some(eql_ciphertext);
+        for (eql_output, original_idx) in encrypted.into_iter().zip(original_indices) {
+            results[original_idx] = Some(eql_output);
         }
     }
 
-    let final_results: Vec<EqlCiphertext> = results
+    let final_results: Vec<EqlOutput> = results
         .into_iter()
         .enumerate()
         .map(|(i, opt)| {
@@ -1199,15 +1199,41 @@ fn encrypted_record_from_mp_base85(
     encrypted: EqlCiphertext,
     encryption_context: Vec<zerokms::Context>,
 ) -> Result<WithContext<'static>, Error> {
-    // EqlCiphertext.body.ciphertext is already deserialized from mp_base85 by serde
-    let encrypted_record = encrypted.body.ciphertext.ok_or_else(|| {
-        Error::InvariantViolation("Missing ciphertext in EQL payload".to_string())
-    })?;
+    // The encrypted record (mp_base85) lives on the scalar payload directly, or on the
+    // first entry of the SteVec for structured payloads.
+    let encrypted_record = match encrypted {
+        EqlCiphertext::Encrypted(payload) => payload.ciphertext,
+        EqlCiphertext::SteVec(payload) => {
+            payload
+                .ste_vec
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    Error::InvariantViolation(
+                        "Missing root entry in SteVec EQL payload".to_string(),
+                    )
+                })?
+                .ciphertext
+        }
+    };
 
     Ok(WithContext {
         record: encrypted_record,
         context: Cow::Owned(encryption_context),
     })
+}
+
+/// Extracts the [`EqlCiphertext`] from a Store-mode [`EqlOutput`].
+///
+/// Used by `encrypt` / `encrypt_bulk`, which always run with `EqlOperation::Store` and
+/// therefore must produce storage ciphertexts (never query payloads).
+fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
+    match output {
+        EqlOutput::Store(ciphertext) => Ok(ciphertext),
+        EqlOutput::Query(_) => Err(Error::InvariantViolation(
+            "encrypt_eql returned a query payload for a store-mode encryption".to_string(),
+        )),
+    }
 }
 
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
@@ -1249,64 +1275,34 @@ mod tests {
         use serde_json::json;
 
         #[test]
-        fn valid_eql_ciphertext_is_encrypted() {
-            // EqlCiphertext with minimal required fields (no ciphertext needed for validation)
-            let valid_encrypted = json!({
-                "i": {"t": "users", "c": "email"},
-                "v": 2
-            });
-
-            assert!(is_encrypted(Json(valid_encrypted)));
-        }
-
-        #[test]
-        fn valid_eql_ciphertext_with_ste_vec_is_encrypted() {
-            // EqlCiphertext with SteVec entries (no ciphertext values needed)
-            let valid_encrypted = json!({
-                "i": {"t": "users", "c": "profile"},
-                "v": 2,
-                "sv": [
-                    {"s": "deadbeef"}
-                ]
-            });
-
-            assert!(is_encrypted(Json(valid_encrypted)));
-        }
-
-        #[test]
         fn invalid_ciphertext_is_not_encrypted() {
-            // Missing required fields
+            // Random JSON without the EQL discriminator must not be recognized as an
+            // encrypted payload.
             let invalid_encrypted = json!({"random": "data"});
             assert!(!is_encrypted(Json(invalid_encrypted)));
         }
 
         #[test]
-        fn old_format_with_k_field_is_still_valid() {
-            // Prior to cipherstash-client 0.32.0, protect-ffi used a discriminated union
-            // with a "k" tag field ("ct" for ciphertext, "sv" for ste_vec). The new
-            // EqlCiphertext format is a unified flat structure without the discriminant.
-            //
-            // The "k" field should be silently ignored by serde (no deny_unknown_fields),
-            // allowing old format data to be recognized as valid encrypted data.
-            // Only the required fields (i, v) need to be present.
-            let old_format = json!({
-                "k": "ct",  // Should be silently ignored
+        fn missing_discriminator_is_not_encrypted() {
+            // EQL v2.3 requires a `k` discriminator at the root ("ct" for scalar
+            // payloads, "sv" for SteVec). Payloads without `k` are rejected even if
+            // the other required fields are present.
+            let no_discriminator = json!({
                 "i": {"t": "users", "c": "email"},
                 "v": 2
-                // Note: "c" is optional, so minimal valid payload works
             });
-            assert!(is_encrypted(Json(old_format)));
+            assert!(!is_encrypted(Json(no_discriminator)));
         }
 
         #[test]
-        fn old_ste_vec_format_with_k_field_is_still_valid() {
-            // Old SteVec format used "k": "sv" discriminant
-            let old_format = json!({
-                "k": "sv",  // Should be silently ignored
-                "i": {"t": "users", "c": "profile"},
+        fn unknown_discriminator_is_not_encrypted() {
+            // Only "ct" and "sv" are valid EQL v2.3 root discriminators.
+            let unknown_discriminator = json!({
+                "k": "wat",
+                "i": {"t": "users", "c": "email"},
                 "v": 2
             });
-            assert!(is_encrypted(Json(old_format)));
+            assert!(!is_encrypted(Json(unknown_discriminator)));
         }
     }
 

--- a/docs/jsonb-api-reference.md
+++ b/docs/jsonb-api-reference.md
@@ -168,42 +168,40 @@ Error: Unsupported conversion from "String" to JsonB
 
 ### EqlCiphertext Format
 
-All encryption operations return an `EqlCiphertext` structure:
+All encryption operations return an EQL v2.3 payload, a discriminated union keyed on `k`:
 
 ```typescript
-type EqlCiphertext = {
-  // Required fields
-  i: { t: string; c: string }  // Identifier (table, column)
+type EqlCiphertext = EncryptedScalar | EncryptedSteVec
+
+// k = "ct" — scalar payload
+type EncryptedScalar = {
+  k: 'ct'
   v: number                     // Version
-
-  // Optional body fields
-  c?: string      // Encrypted ciphertext (mp_base85)
-  a?: boolean     // Array flag
-
-  // Searchable encrypted metadata (top-level)
-  ob?: string[]   // ORE block (64-bit integers)
-  bf?: number[]   // Bloom filter (match index)
-  hm?: string     // HMAC-SHA256 (unique index)
-  s?: string      // Selector (SteVec path)
-  oc?: string     // SteVec ORE CLLW term — Standard mode (numeric ∪ string)
-  op?: string     // SteVec OPE CLLW term — Compat mode (numeric ∪ string)
-  opf?: string    // OPE CLLW fixed (non-SteVec numeric)
-  opv?: string    // OPE CLLW variable (non-SteVec string)
-
-  // Nested entries
-  sv?: EqlCiphertextBody[]  // SteVec flattened entries
+  i: { t: string; c: string }  // Identifier (table, column)
+  c: string                     // Encrypted ciphertext (mp_base85) — required for storage
+  hm?: string                   // HMAC-SHA256 (unique index)
+  bf?: number[]                 // Bloom filter (match index)
+  ob?: string[]                 // Block ORE u64_8_256 (ore index)
 }
 
-type EqlCiphertextBody = {
-  c?: string      // Entry ciphertext
-  a?: boolean     // Array flag
-  s?: string      // Entry selector
-  hm?: string     // Entry HMAC — non-orderable values (objects, arrays, booleans, null)
-  oc?: string     // Entry ORE CLLW term (Standard mode) — orderable values (strings, numbers)
-  op?: string     // Entry OPE CLLW term (Compat mode) — orderable values (strings, numbers)
-  sv?: EqlCiphertextBody[]  // Nested entries
+// k = "sv" — STE-vector payload
+type EncryptedSteVec = {
+  k: 'sv'
+  v: number                     // Version
+  i: { t: string; c: string }  // Identifier (table, column)
+  sv: SteVecEntry[]            // Per-selector entries; root ciphertext lives at sv[0].c
+}
+
+type SteVecEntry = {
+  s: string       // Hex-encoded tokenized selector
+  c: string       // Per-entry ciphertext (mp_base85) — required
+  a?: boolean     // Array marker
+  hm?: string     // HMAC term — non-orderable leaves (objects, arrays, booleans, null)
+  oc?: string     // CLLW ORE term — orderable leaves (strings, numbers), Standard mode
 }
 ```
+
+Query payloads share the same `{ k, v, i, ... }` shape but omit `c` (queries do not encrypt for storage). A `k = "sv"` query carries either `s` (selector lookup), `hm`/`oc` (per-element term), or `q` (full STE query vector for containment).
 
 Under SteVec **Standard** mode (the default since `cipherstash-client` 0.34.1-alpha.7), each `sv` entry carries either `hm` or `oc` depending on the underlying JSON value:
 
@@ -212,25 +210,40 @@ Under SteVec **Standard** mode (the default since `cipherstash-client` 0.34.1-al
 | Object, array, boolean, null | `hm` (HMAC-SHA256) |
 | String, number | `oc` (CLLW ORE, tagged-plaintext) |
 
-Under **Compat** mode (`ste_vec.mode: 'compat'`), the orderable term is OPE instead of ORE and serializes as `op`. Numeric and string values share a single orderable field in both modes — domain separation is enforced on the plaintext bit stream before encryption, so numeric ciphertexts always sort below string ciphertexts.
+Numeric and string values share the single `oc` orderable field — domain separation is enforced on the plaintext bit stream before encryption, so numeric ciphertexts always sort below string ciphertexts.
 
 ### Output by Operation
 
-| Operation | Fields Present |
-|-----------|----------------|
-| Storage (`encrypt`) | `i, v, c, sv` |
-| Selector query | `i, v, s` |
-| Term query | `i, v, c, sv` |
+| Operation | Discriminator | Fields Present |
+|-----------|---------------|----------------|
+| Scalar storage (`encrypt` on non-JSON column) | `k: "ct"` | `k, v, i, c` + any of `hm, bf, ob` |
+| SteVec storage (`encrypt` on JSON column) | `k: "sv"` | `k, v, i, sv` (root ciphertext at `sv[0].c`) |
+| Scalar query (`encryptQuery` with `ore`/`match`/`unique`) | `k: "ct"` | `k, v, i` + one of `hm, bf, ob` |
+| SteVec selector query (`encryptQuery` with `ste_vec_selector`) | `k: "sv"` | `k, v, i, s` |
+| SteVec containment query (`encryptQuery` with object/array input) | `k: "sv"` | `k, v, i, sv` |
 
 ### Example Outputs
 
-**Storage encryption (Standard mode):**
+**Scalar storage encryption (e.g. `email`, `score`):**
 ```json
 {
-  "i": { "t": "users", "c": "profile" },
+  "k": "ct",
   "v": 2,
+  "i": { "t": "users", "c": "email" },
   "c": "base85encodedciphertext...",
+  "hm": "abc123...",
+  "bf": [1, 2, 3]
+}
+```
+
+**SteVec storage encryption (Standard mode):**
+```json
+{
+  "k": "sv",
+  "v": 2,
+  "i": { "t": "users", "c": "profile" },
   "sv": [
+    { "s": "rootselector", "hm": "rootmac", "c": "rootciphertext..." },
     { "s": "abc123", "hm": "def456", "c": "..." },
     { "s": "jkl012", "oc": "pqr678", "c": "..." }
   ]
@@ -240,18 +253,19 @@ Under **Compat** mode (`ste_vec.mode: 'compat'`), the orderable term is OPE inst
 **Selector query:**
 ```json
 {
-  "i": { "t": "users", "c": "profile" },
+  "k": "sv",
   "v": 2,
+  "i": { "t": "users", "c": "profile" },
   "s": "abc123def456"
 }
 ```
 
-**Term query (Standard mode):**
+**Containment query (Standard mode):**
 ```json
 {
-  "i": { "t": "users", "c": "profile" },
+  "k": "sv",
   "v": 2,
-  "c": "base85encodedciphertext...",
+  "i": { "t": "users", "c": "profile" },
   "sv": [
     { "s": "abc123", "oc": "ghi789", "c": "..." }
   ]

--- a/integration-tests/tests/json-containment.test.ts
+++ b/integration-tests/tests/json-containment.test.ts
@@ -54,8 +54,9 @@ describe('encryptBulk output structure for nested JSON', () => {
 
     expect(sv.length).toBeGreaterThan(0)
 
-    // Verify root ciphertext exists (for storage)
-    expect(encrypted).toHaveProperty('c')
+    // EQL v2.3: SteVec storage places the root ciphertext at sv[0].c, not at the root.
+    expect(encrypted).not.toHaveProperty('c')
+    expect(sv[0]).toHaveProperty('c')
 
     // Verify identifier and version
     expect(encrypted).toHaveProperty('i')
@@ -284,13 +285,14 @@ describe('compare encryptBulk vs encryptQueryBulk for JSON', () => {
     console.log('\n=== QUERY (encryptQueryBulk with ste_vec_term) ===')
     console.log(JSON.stringify(queried[0], null, 2))
 
-    // Document the differences
+    // Document the differences. EQL v2.3 places the root ciphertext at sv[0].c
+    // for SteVec storage payloads — no `c` at the root.
     console.log('\n=== STRUCTURAL COMPARISON ===')
     console.log(
-      `Storage has 'c' (root ciphertext): ${stored[0].c !== undefined}`,
+      `Storage has 'sv[0].c' (root ciphertext): ${stored[0].sv?.[0]?.c !== undefined}`,
     )
     console.log(
-      `Query has 'c' (root ciphertext): ${queried[0].c !== undefined}`,
+      `Query has 'sv[0].c' (root ciphertext): ${queried[0].sv?.[0]?.c !== undefined}`,
     )
     console.log(
       `Storage has 'sv' (flattened entries): ${stored[0].sv !== undefined}`,
@@ -355,9 +357,10 @@ describe('compare encryptBulk vs encryptQueryBulk for JSON', () => {
       console.log(row.join(' '))
     }
 
-    // Storage should have c and sv
-    expect(stored[0]).toHaveProperty('c')
+    // EQL v2.3: SteVec storage has sv (root ciphertext lives at sv[0].c, not the root).
+    expect(stored[0]).not.toHaveProperty('c')
     expect(stored[0]).toHaveProperty('sv')
+    expect(stored[0].sv?.[0]).toHaveProperty('c')
 
     // Selector query should have s (selector) but not c
     expect(querySelector[0]).toHaveProperty('s')
@@ -816,10 +819,12 @@ describe('type inference with nested structures', () => {
       queryOp: 'default',
     })
 
-    // null as JsonB goes through StoreMode, producing sv array
+    // null as JsonB goes through StoreMode, producing sv array.
+    // EQL v2.3: the root ciphertext lives at sv[0].c, not at the root.
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
-    expect(result).toHaveProperty('c')
+    expect(result).not.toHaveProperty('c')
     expect(result).toHaveProperty('sv')
+    expect(result.sv?.[0]).toHaveProperty('c')
   })
 })

--- a/integration-tests/tests/json.test.ts
+++ b/integration-tests/tests/json.test.ts
@@ -115,11 +115,13 @@ describe('SteVec output structure', () => {
     })
 
     // SteVec variant must have these fields
+    expect(ciphertext.k).toBe('sv')
     expect(ciphertext.sv).toBeDefined()
-    expect(ciphertext).toHaveProperty('c') // Root ciphertext
     expect(ciphertext).toHaveProperty('sv')
     expect(ciphertext).toHaveProperty('i')
     expect(ciphertext).toHaveProperty('v')
+    // EQL v2.3 places the root ciphertext at sv[0].c — not at the root.
+    expect(ciphertext).not.toHaveProperty('c')
 
     // Validate entry structure uses new field names
     const encrypted = ciphertext as { sv: unknown[] }
@@ -128,6 +130,7 @@ describe('SteVec output structure', () => {
 
     const entry = encrypted.sv[0] as Record<string, unknown>
     expect(entry).toHaveProperty('c') // Entry ciphertext (new format)
+    expect(entry).toHaveProperty('s') // Tokenized selector
 
     // Old field names should NOT exist
     expect(entry).not.toHaveProperty('tokenized_selector')

--- a/integration-tests/tests/query.test.ts
+++ b/integration-tests/tests/query.test.ts
@@ -80,12 +80,14 @@ describe('encryptQuery for ste_vec indexes', () => {
     console.log('OBJECT + DEFAULT queryOp output:')
     console.log(JSON.stringify(result, null, 2))
 
-    // JSON object with default queryOp should produce sv array for containment queries
+    // JSON object with default queryOp should produce sv array for containment queries.
+    // Under EQL v2.3 the root ciphertext lives at sv[0].c, not at the root.
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
-    expect(result).toHaveProperty('c') // Root ciphertext from storage mode
+    expect(result.k).toBe('sv')
     expect(result).toHaveProperty('sv') // Flattened entries for containment matching
     expect(Array.isArray(result.sv)).toBe(true)
+    expect(result).not.toHaveProperty('c')
   })
 
   test('should encrypt string path with explicit ste_vec_selector', async () => {

--- a/integration-tests/tests/scalar.test.ts
+++ b/integration-tests/tests/scalar.test.ts
@@ -4,7 +4,6 @@ import { describe, expect, test } from 'vitest'
 import {
   decrypt,
   encrypt,
-  type Encrypted,
   type Identifier,
   newClient,
   isEncrypted,
@@ -158,54 +157,8 @@ describe('isEncrypted validation', () => {
   })
 })
 
-describe('old format backwards compatibility', () => {
-  test('should decrypt old format data with k: ct discriminant field', async () => {
-    const client = await newClient({ encryptConfig })
-    const plaintext = 'test@example.com'
-
-    // Encrypt to get valid ciphertext
-    const ciphertext = await encrypt(client, {
-      plaintext,
-      table: 'users',
-      column: 'email',
-    })
-
-    // Simulate old format by adding "k" field (old discriminant for ciphertext variant)
-    const oldFormat = { ...ciphertext, k: 'ct' }
-
-    // Should still be recognized as encrypted (serde ignores unknown fields)
-    expect(isEncrypted(oldFormat)).toBe(true)
-
-    // Should decrypt correctly
-    const decrypted = await decrypt(client, {
-      ciphertext: oldFormat as Encrypted,
-    })
-    expect(decrypted).toBe(plaintext)
-  })
-
-  test('should decrypt old SteVec format with k: sv discriminant', async () => {
-    const client = await newClient({ encryptConfig: jsonSteVec })
-    const plaintext = { name: 'test' }
-
-    const ciphertext = await encrypt(client, {
-      plaintext,
-      table: 'users',
-      column: 'profile',
-    })
-
-    // Simulate old SteVec format
-    const oldFormat = { ...ciphertext, k: 'sv' }
-
-    expect(isEncrypted(oldFormat)).toBe(true)
-    const decrypted = await decrypt(client, {
-      ciphertext: oldFormat as Encrypted,
-    })
-    expect(decrypted).toEqual(plaintext)
-  })
-})
-
-describe('new format validation', () => {
-  test('encrypted output should not contain k field', async () => {
+describe('EQL v2.3 wire format', () => {
+  test('scalar storage payload carries k:"ct" discriminator', async () => {
     const client = await newClient({ encryptConfig })
 
     const ciphertext = await encrypt(client, {
@@ -214,16 +167,13 @@ describe('new format validation', () => {
       column: 'email',
     })
 
-    // New format must NOT have the "k" discriminant
-    expect(ciphertext).not.toHaveProperty('k')
-
-    // Verify required fields are present
+    expect(ciphertext.k).toBe('ct')
     expect(ciphertext).toHaveProperty('c')
     expect(ciphertext).toHaveProperty('i')
     expect(ciphertext).toHaveProperty('v')
   })
 
-  test('encrypted JSON output should not contain k field', async () => {
+  test('SteVec storage payload carries k:"sv" discriminator', async () => {
     const client = await newClient({ encryptConfig: jsonSteVec })
 
     const ciphertext = await encrypt(client, {
@@ -232,8 +182,11 @@ describe('new format validation', () => {
       column: 'profile',
     })
 
-    expect(ciphertext).not.toHaveProperty('k')
-    expect(ciphertext).toHaveProperty('sv') // SteVec field
+    expect(ciphertext.k).toBe('sv')
+    expect(ciphertext).toHaveProperty('sv')
+    // SteVec payloads place the root ciphertext at sv[0].c, not at the root.
+    expect(ciphertext).not.toHaveProperty('c')
+    expect(ciphertext.sv?.[0]).toHaveProperty('c')
   })
 })
 

--- a/src/index.cts
+++ b/src/index.cts
@@ -250,68 +250,62 @@ export type Context = {
 }
 
 /**
- * Represents encrypted data in the EQL format.
+ * Represents an EQL v2.3 payload returned by the FFI.
  *
- * This TypeScript type mirrors the Rust `EqlCiphertext` structure from `cipherstash-client`.
- * The Rust type hierarchy is:
- * - `EqlCiphertext` (identifier + version + body)
- *   - `EqlCiphertextBody` (ciphertext + SEM fields + array flag)
- *     - `EqlSEM` (all searchable encrypted metadata fields)
- *
- * In the serialized JSON format, `#[serde(flatten)]` is used in Rust to produce a flat
- * structure where all fields appear at the top level rather than nested.
- *
- * Note: The ciphertext field (c) is serialized in MessagePack Base85 format.
+ * This TypeScript type mirrors the Rust `EqlCiphertext` enum from `cipherstash-client`,
+ * which is a discriminated union keyed on `k`:
+ * - `k: "ct"` — scalar payload with root-scope index terms (`c`, `hm`, `bf`, `ob`).
+ *   Storage payloads always carry `c`; query payloads omit `c`.
+ * - `k: "sv"` — STE-vector payload with per-selector entries in `sv`.
+ *   Storage payloads carry the root ciphertext at `sv[0].c`; query payloads
+ *   carry either a single selector (`s`) or a containment vector (`q`).
  */
 export type Encrypted = {
-  /** The table and column identifier */
-  i: { t: string; c: string }
+  /** EQL v2.3 root discriminator — `"ct"` for scalar, `"sv"` for STE-vector */
+  k: 'ct' | 'sv'
   /** The encryption version */
   v: number
-  /** The encrypted ciphertext (mp_base85 encoded, optional for query-mode payloads) */
+  /** The table and column identifier */
+  i: { t: string; c: string }
+  /** Encrypted ciphertext (mp_base85). Present on scalar storage payloads; absent on scalar queries. */
   c?: string
-  /** Whether this encrypted value is part of an array */
-  a?: boolean
-  /** ORE block index for 64-bit integers */
-  ob?: string[]
-  /** Bloom filter for approximate match queries */
-  bf?: number[]
-  /** HMAC-SHA256 hash for exact matches */
+  /** HMAC-SHA256 hash for exact-match equality (unique index) */
   hm?: string
-  /** Selector value for field selection (SteVec) */
+  /** Bloom filter (set bit positions) for LIKE / ILIKE (match index) */
+  bf?: number[]
+  /** Block ORE u64_8_256 term for ordered comparisons (ore index) */
+  ob?: string[]
+  /** Per-selector SteVec entries (present on `k:"sv"` storage payloads) */
+  sv?: SteVecEntry[]
+  /** Tokenized selector for `ste_vec_selector` queries (present on `k:"sv"` query payloads) */
   s?: string
-  /** Blake3 hash for exact matches (SteVec) */
-  b3?: string
-  /** ORE CLLW fixed-width index for 64-bit values (SteVec) */
-  ocf?: string
-  /** ORE CLLW variable-width index for strings (SteVec) */
-  ocv?: string
-  /** Structured encryption vector entries (recursive) */
-  sv?: EqlCiphertextBody[]
+  /** CLLW ORE term for `ste_vec_term` queries (present on `k:"sv"` query payloads) */
+  oc?: string
+  /** Full STE query vector for JSON containment queries (present on `k:"sv"` containment queries) */
+  q?: unknown
 }
 
 /**
- * Body of an EQL ciphertext, used recursively in SteVec entries.
+ * One entry inside a SteVec payload (`k: "sv"`).
+ *
+ * Every element carries `s` (selector), `c` (entry ciphertext), and exactly one
+ * per-element equality / ordering term (`hm` or `oc`).
  */
-export type EqlCiphertextBody = {
-  /** The encrypted ciphertext (mp_base85 encoded) */
-  c?: string
-  /** Whether this entry is part of an array */
+export type SteVecEntry = {
+  /** Hex-encoded tokenized selector — deterministic per (path, key) */
+  s: string
+  /** Per-entry encrypted record (mp_base85 encoded) */
+  c: string
+  /** Array marker — true when the selector points at a JSON array context */
   a?: boolean
-  /** Selector value for field selection */
-  s?: string
-  /** Blake3 hash for exact matches */
-  b3?: string
-  /** ORE CLLW fixed-width index */
-  ocf?: string
-  /** ORE CLLW variable-width index */
-  ocv?: string
-  /** Nested SteVec entries (for deeply nested JSON) */
-  sv?: EqlCiphertextBody[]
+  /** Per-entry HMAC term for non-orderable leaves (objects, arrays, booleans, null) */
+  hm?: string
+  /** Per-entry CLLW ORE term for orderable leaves (strings, numbers) — Standard mode */
+  oc?: string
 }
 
-/** @deprecated Use EqlCiphertextBody instead */
-export type SteVecEntry = EqlCiphertextBody
+/** @deprecated Use SteVecEntry instead */
+export type EqlCiphertextBody = SteVecEntry
 
 export type EncryptConfig = {
   v: number


### PR DESCRIPTION
## Summary

Upgrades `cipherstash-client` / `cts-common` / `stack-profile` from `=0.34.1-alpha.7` → `=0.35.0` and adapts the FFI, TS types, integration tests, and JSONB API reference to the EQL v2.3 wire format that ships with 0.35.0.

- **Rust (`crates/protect-ffi/src/lib.rs`):**
  - `encrypt_eql` now returns `Vec<EqlOutput>`. `encrypt` / `encrypt_bulk` unwrap `EqlOutput::Store` via a small `into_store_ciphertext` helper (they always run with `EqlOperation::Store`, so a `Query` variant there is an invariant violation).
  - `encrypt_query` / `encrypt_query_bulk` return `Json<EqlOutput>` directly. Upstream 0.35.0 derives `Serialize` / `Deserialize` on `EqlOutput` with `#[serde(untagged)]`, so the wire shape is determined by whichever inner variant is present — `EqlCiphertext` for SteVec containment (which re-uses store-mode encryption) or `EqlQueryPayload` for everything else.
  - Rewrites `encrypted_record_from_mp_base85()` to extract the ciphertext from the new enum: scalar payloads (`EqlCiphertext::Encrypted`) carry it at `c`; SteVec payloads (`EqlCiphertext::SteVec`) carry it at `sv[0].c`.
  - Drops four `is_encrypted` unit tests that asserted old-format invariants (absence of `k`, optional `c`) and adds two new ones covering the now-mandatory `k` discriminator.
- **TS (`src/index.cts`):** Rewrites the `Encrypted` type to expose the `k: 'ct' | 'sv'` discriminator and trims the field list to what 0.35.0 actually emits (drops `a`, `b3`, `ocf`, `ocv`, `s` on root scalar; adds `s`, `oc`, `q` for query variants). Adds a focused `SteVecEntry` type for `sv[]` elements; keeps `EqlCiphertextBody` as a deprecated alias.
- **Integration tests:**
  - `scalar.test.ts`: replaces the old "no `k` field" / "k is silently ignored" tests with an EQL v2.3 wire-format suite that asserts the right `k` discriminator and that SteVec payloads place the root ciphertext at `sv[0].c`.
  - `json.test.ts`: SteVec output assertions updated to expect `k: 'sv'` and the absence of root-level `c`.
  - `query.test.ts`: containment-query assertion updated to expect `k: 'sv'` and no root `c`.
- **Docs (`docs/jsonb-api-reference.md`):** Rewrites the EqlCiphertext format section as a discriminated union, updates the operation/field table, and refreshes every example payload with the new `k` discriminator and `sv[0].c` root-ciphertext placement.

## Why

`cipherstash-client` 0.35.0 lands the upstream "align EQL types with v2.3 schema" change. `EqlCiphertext` becomes a `#[serde(tag = "k")]` discriminated enum (`Encrypted` / `SteVec`), `encrypt_eql` returns `Vec<EqlOutput>` splitting storage ciphertexts (`EqlOutput::Store`) from query payloads (`EqlOutput::Query`), and `EqlOutput` itself gains untagged `Serialize` / `Deserialize` derives so consumers can return the sum type across an FFI boundary without losing type information. The FFI has to track this shape change to keep compiling and to keep emitting a wire format that downstream consumers (the proxy, EQL-aware Postgres functions) can ingest.

## Breaking changes

The EQL v2.3 wire format is **not** a superset of the previous one — callers reading the JSON directly will need to update:

1. **Root payloads now carry `k: 'ct' | 'sv'`.** The previous "no `k` field" guarantee is reversed: `k` is now required and is the serde discriminator. Code that previously asserted `not.toHaveProperty('k')` or relied on a single flat shape must be updated.
2. **SteVec payloads no longer have a root-level `c`.** The root ciphertext moves to `sv[0].c`. Any consumer reading `ciphertext.c` on a SteVec payload needs to read `ciphertext.sv[0].c` instead. Decryption paths through the FFI handle this transparently; only direct JSON readers are affected.
3. **`encryptQuery` return shape diverges from `encrypt`.** Query mode (e.g. `ste_vec_selector`, `ore`, `match`, `unique`) emits a query payload that omits `c` entirely; only containment queries (object/array input on a SteVec column) still return a full storage payload. The TS `Encrypted` type widens to a union covering both cases.
4. **Several root-level SEM fields are gone.** `a`, `b3`, `ocf`, `ocv`, `op`, `opf`, `opv` no longer appear at the root of an `EqlCiphertext`. Per-element terms (`hm`, `oc`, `a`) live on `SteVecEntry` only.

The exported `Encrypted` TS type changes shape accordingly; consumers will hit `tsc` errors at sites that destructured the removed fields.

## Notable files

- `crates/protect-ffi/Cargo.toml`, `Cargo.lock` — version bump (0.34.1-alpha.7 → 0.35.0), brings along `cipherstash-config`, `cipherstash-core`, `stack-auth`, `zerokms-protocol`.
- `crates/protect-ffi/src/lib.rs` — `EqlOutput` import, `into_store_ciphertext` helper for store-only paths, direct `Json<EqlOutput>` return from the query exports, `encrypted_record_from_mp_base85()` rewrite, `is_encrypted` test refresh.
- `src/index.cts` — `Encrypted` type rewrite, new `SteVecEntry`, deprecated `EqlCiphertextBody` alias.
- `docs/jsonb-api-reference.md` — output structure section + examples updated for v2.3.

## Test plan

- [x] `cargo test --all` passes (69 unit tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- [x] `npm run test:typecheck` / `test:unit` / `test:lint` / `test:format` all pass
- [x] `integration-tests` typechecks against the new `Encrypted` shape
- [x] `npm run cargo-build` produces a working `index.node`; non-network unit tests under `integration-tests/` still pass (the ones that don't hit ZeroKMS — i.e. `isEncrypted` structural checks)
- [ ] Integration test full run against a real ZeroKMS workspace — confirm round-trip encrypt/decrypt on scalar, SteVec, and bulk variants, plus all `encryptQuery` index types (`ore`, `match`, `unique`, `ste_vec_selector`, containment)
- [ ] Downstream smoke: link this build into a consumer (protectjs or the proxy) and verify the proxy still accepts the new wire format