### PR TITLE
Refactor/upgrade cipherstash client follow up

### DIFF
--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1199,14 +1199,8 @@ fn encrypted_record_from_mp_base85(
     encrypted: EqlCiphertext,
     encryption_context: Vec<zerokms::Context>,
 ) -> Result<WithContext<'static>, Error> {
-    // The encrypted record (mp_base85) lives on the scalar payload directly, or on the
-    // first entry of the SteVec for structured payloads.
-    //
-    // The SteVec invariant — root record is always `sv[0]` — is established by upstream
-    // (`SteVec::into_root_ciphertext` in `cipherstash-client`'s encryption crate, and
-    // `extract_root_ciphertext` in the EQL crate, both of which take `into_iter().next()`).
-    // Neither accessor is exposed on the public `SteVecPayload` wire type, so we mirror
-    // the pattern here.
+    // SteVec root invariant: ciphertext is always `sv[0]` (mirrors upstream
+    // `SteVec::into_root_ciphertext`, which is not exposed on the wire type).
     let encrypted_record = match encrypted {
         EqlCiphertext::Encrypted(payload) => payload.ciphertext,
         EqlCiphertext::SteVec(payload) => {
@@ -1297,9 +1291,6 @@ mod tests {
 
         #[test]
         fn valid_scalar_ciphertext_is_encrypted() {
-            // A well-formed `k = "ct"` storage payload must round-trip through
-            // is_encrypted as true. Guards against regressions where the predicate
-            // collapses to always-false.
             let payload = EqlCiphertext::Encrypted(EncryptedPayload {
                 version: EQL_SCHEMA_VERSION,
                 identifier: EqlIdentifier::new("users", "email"),
@@ -1315,8 +1306,6 @@ mod tests {
 
         #[test]
         fn valid_ste_vec_ciphertext_is_encrypted() {
-            // A well-formed `k = "sv"` storage payload (with a root SteVec entry)
-            // must round-trip through is_encrypted as true.
             let payload = EqlCiphertext::SteVec(SteVecPayload {
                 version: EQL_SCHEMA_VERSION,
                 identifier: EqlIdentifier::new("users", "profile"),

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -1201,6 +1201,12 @@ fn encrypted_record_from_mp_base85(
 ) -> Result<WithContext<'static>, Error> {
     // The encrypted record (mp_base85) lives on the scalar payload directly, or on the
     // first entry of the SteVec for structured payloads.
+    //
+    // The SteVec invariant — root record is always `sv[0]` — is established by upstream
+    // (`SteVec::into_root_ciphertext` in `cipherstash-client`'s encryption crate, and
+    // `extract_root_ciphertext` in the EQL crate, both of which take `into_iter().next()`).
+    // Neither accessor is exposed on the public `SteVecPayload` wire type, so we mirror
+    // the pattern here.
     let encrypted_record = match encrypted {
         EqlCiphertext::Encrypted(payload) => payload.ciphertext,
         EqlCiphertext::SteVec(payload) => {
@@ -1272,7 +1278,61 @@ mod tests {
 
     mod is_encrypted {
         use super::*;
+        use cipherstash_client::eql::{
+            EncryptedPayload, SteVecEntry, SteVecEntryTerm, SteVecPayload, EQL_SCHEMA_VERSION,
+        };
+        use cipherstash_client::zerokms::EncryptedRecord;
         use serde_json::json;
+
+        fn dummy_encrypted_record() -> EncryptedRecord {
+            EncryptedRecord {
+                iv: Default::default(),
+                ciphertext: vec![1; 16],
+                tag: vec![2; 16],
+                descriptor: "users/email".to_string(),
+                keyset_id: None,
+                decryption_policy: None,
+            }
+        }
+
+        #[test]
+        fn valid_scalar_ciphertext_is_encrypted() {
+            // A well-formed `k = "ct"` storage payload must round-trip through
+            // is_encrypted as true. Guards against regressions where the predicate
+            // collapses to always-false.
+            let payload = EqlCiphertext::Encrypted(EncryptedPayload {
+                version: EQL_SCHEMA_VERSION,
+                identifier: EqlIdentifier::new("users", "email"),
+                ciphertext: dummy_encrypted_record(),
+                hmac_256: None,
+                bloom_filter: None,
+                ore_block_u64_8_256: None,
+            });
+            let value = serde_json::to_value(&payload).unwrap();
+            assert_eq!(value["k"], "ct");
+            assert!(is_encrypted(Json(value)));
+        }
+
+        #[test]
+        fn valid_ste_vec_ciphertext_is_encrypted() {
+            // A well-formed `k = "sv"` storage payload (with a root SteVec entry)
+            // must round-trip through is_encrypted as true.
+            let payload = EqlCiphertext::SteVec(SteVecPayload {
+                version: EQL_SCHEMA_VERSION,
+                identifier: EqlIdentifier::new("users", "profile"),
+                ste_vec: vec![SteVecEntry {
+                    selector: "deadbeef".into(),
+                    ciphertext: dummy_encrypted_record(),
+                    is_array: None,
+                    term: SteVecEntryTerm::Hmac {
+                        hmac_256: "feedface".into(),
+                    },
+                }],
+            });
+            let value = serde_json::to_value(&payload).unwrap();
+            assert_eq!(value["k"], "sv");
+            assert!(is_encrypted(Json(value)));
+        }
 
         #[test]
         fn invalid_ciphertext_is_not_encrypted() {

--- a/docs/jsonb-api-reference.md
+++ b/docs/jsonb-api-reference.md
@@ -201,7 +201,7 @@ type SteVecEntry = {
 }
 ```
 
-Query payloads share the same `{ k, v, i, ... }` shape but omit `c` (queries do not encrypt for storage). A `k = "sv"` query carries either `s` (selector lookup), `hm`/`oc` (per-element term), or `q` (full STE query vector for containment).
+Query payloads share the same `{ k, v, i, ... }` shape but omit `c` at the root (queries do not encrypt for storage). For `k = "ct"` queries, the payload carries exactly one of `hm`, `bf`, or `ob`. For `k = "sv"` queries, the FFI emits two shapes: selector queries (`ste_vec_selector`) carry a single tokenized `s`; containment queries (`ste_vec_term`) are emitted as full SteVec storage payloads with an `sv` array — see the *Output by Operation* table below.
 
 Under SteVec **Standard** mode (the default since `cipherstash-client` 0.34.1-alpha.7), each `sv` entry carries either `hm` or `oc` depending on the underlying JSON value:
 

--- a/integration-tests/tests/common.ts
+++ b/integration-tests/tests/common.ts
@@ -1,4 +1,33 @@
-import type { EncryptConfig } from '../../lib/index.cjs'
+import type {
+  Encrypted,
+  EncryptedScalar,
+  EncryptedSteVec,
+  EncryptConfig,
+} from '../../lib/index.cjs'
+
+/**
+ * Narrows an `Encrypted` payload to the `k: "sv"` variant for assertion-based
+ * tests. Throws if the payload is not a SteVec — covers the common test pattern
+ * where we encrypted a JSON column and expect a SteVec storage payload.
+ */
+export function assertSteVec(
+  payload: Encrypted,
+): asserts payload is EncryptedSteVec {
+  if (payload.k !== 'sv') {
+    throw new Error(`expected k:"sv" payload, got k:"${payload.k}"`)
+  }
+}
+
+/**
+ * Narrows an `Encrypted` payload to the `k: "ct"` variant. Throws otherwise.
+ */
+export function assertScalar(
+  payload: Encrypted,
+): asserts payload is EncryptedScalar {
+  if (payload.k !== 'ct') {
+    throw new Error(`expected k:"ct" payload, got k:"${payload.k}"`)
+  }
+}
 
 export const encryptConfig: EncryptConfig = {
   v: 1,

--- a/integration-tests/tests/common.ts
+++ b/integration-tests/tests/common.ts
@@ -5,11 +5,6 @@ import type {
   EncryptConfig,
 } from '../../lib/index.cjs'
 
-/**
- * Narrows an `Encrypted` payload to the `k: "sv"` variant for assertion-based
- * tests. Throws if the payload is not a SteVec — covers the common test pattern
- * where we encrypted a JSON column and expect a SteVec storage payload.
- */
 export function assertSteVec(
   payload: Encrypted,
 ): asserts payload is EncryptedSteVec {
@@ -18,9 +13,6 @@ export function assertSteVec(
   }
 }
 
-/**
- * Narrows an `Encrypted` payload to the `k: "ct"` variant. Throws otherwise.
- */
 export function assertScalar(
   payload: Encrypted,
 ): asserts payload is EncryptedScalar {

--- a/integration-tests/tests/json-containment.test.ts
+++ b/integration-tests/tests/json-containment.test.ts
@@ -45,7 +45,6 @@ describe('encryptBulk output structure for nested JSON', () => {
     expect(result).toHaveLength(1)
     const encrypted = result[0]
 
-    // Verify sv structure exists
     assertSteVec(encrypted)
     expect(encrypted).toHaveProperty('sv')
     expect(Array.isArray(encrypted.sv)).toBe(true)
@@ -293,8 +292,6 @@ describe('compare encryptBulk vs encryptQueryBulk for JSON', () => {
     assertSteVec(storedEnc)
     assertSteVec(queriedEnc)
 
-    // Document the differences. EQL v2.3 places the root ciphertext at sv[0].c
-    // for SteVec storage payloads — no `c` at the root.
     console.log('\n=== STRUCTURAL COMPARISON ===')
     console.log(
       `Storage has 'sv[0].c' (root ciphertext): ${storedEnc.sv?.[0]?.c !== undefined}`,

--- a/integration-tests/tests/json-containment.test.ts
+++ b/integration-tests/tests/json-containment.test.ts
@@ -10,7 +10,7 @@ import {
   newClient,
 } from '@cipherstash/protect-ffi'
 
-import { jsonSteVec } from './common.js'
+import { assertSteVec, jsonSteVec } from './common.js'
 
 /**
  * JSON Containment Investigation Tests
@@ -46,6 +46,7 @@ describe('encryptBulk output structure for nested JSON', () => {
     const encrypted = result[0]
 
     // Verify sv structure exists
+    assertSteVec(encrypted)
     expect(encrypted).toHaveProperty('sv')
     expect(Array.isArray(encrypted.sv)).toBe(true)
 
@@ -89,6 +90,7 @@ describe('encryptBulk output structure for nested JSON', () => {
     const result = await encryptBulk(client, { plaintexts })
     const encrypted = result[0]
 
+    assertSteVec(encrypted)
     expect(encrypted.sv).toBeDefined()
 
     const sv = encrypted.sv
@@ -147,6 +149,7 @@ describe('encryptBulk output structure for nested JSON', () => {
     const result = await encryptBulk(client, { plaintexts })
     const encrypted = result[0]
 
+    assertSteVec(encrypted)
     expect(encrypted.sv).toBeDefined()
 
     const sv = encrypted.sv
@@ -285,31 +288,36 @@ describe('compare encryptBulk vs encryptQueryBulk for JSON', () => {
     console.log('\n=== QUERY (encryptQueryBulk with ste_vec_term) ===')
     console.log(JSON.stringify(queried[0], null, 2))
 
+    const storedEnc = stored[0]
+    const queriedEnc = queried[0]
+    assertSteVec(storedEnc)
+    assertSteVec(queriedEnc)
+
     // Document the differences. EQL v2.3 places the root ciphertext at sv[0].c
     // for SteVec storage payloads — no `c` at the root.
     console.log('\n=== STRUCTURAL COMPARISON ===')
     console.log(
-      `Storage has 'sv[0].c' (root ciphertext): ${stored[0].sv?.[0]?.c !== undefined}`,
+      `Storage has 'sv[0].c' (root ciphertext): ${storedEnc.sv?.[0]?.c !== undefined}`,
     )
     console.log(
-      `Query has 'sv[0].c' (root ciphertext): ${queried[0].sv?.[0]?.c !== undefined}`,
+      `Query has 'sv[0].c' (root ciphertext): ${queriedEnc.sv?.[0]?.c !== undefined}`,
     )
     console.log(
-      `Storage has 'sv' (flattened entries): ${stored[0].sv !== undefined}`,
+      `Storage has 'sv' (flattened entries): ${storedEnc.sv !== undefined}`,
     )
     console.log(
-      `Query has 'sv' (flattened entries): ${queried[0].sv !== undefined}`,
+      `Query has 'sv' (flattened entries): ${queriedEnc.sv !== undefined}`,
     )
 
-    if (stored[0].sv && queried[0].sv) {
-      console.log(`Storage sv count: ${stored[0].sv.length}`)
-      console.log(`Query sv count: ${queried[0].sv.length}`)
+    if (storedEnc.sv && queriedEnc.sv) {
+      console.log(`Storage sv count: ${storedEnc.sv.length}`)
+      console.log(`Query sv count: ${queriedEnc.sv.length}`)
     }
 
-    expect(stored[0]).toHaveProperty('i')
-    expect(stored[0]).toHaveProperty('v')
-    expect(queried[0]).toHaveProperty('i')
-    expect(queried[0]).toHaveProperty('v')
+    expect(storedEnc).toHaveProperty('i')
+    expect(storedEnc).toHaveProperty('v')
+    expect(queriedEnc).toHaveProperty('i')
+    expect(queriedEnc).toHaveProperty('v')
   })
 
   test('compare storage vs query (selector operation only)', async () => {
@@ -357,10 +365,13 @@ describe('compare encryptBulk vs encryptQueryBulk for JSON', () => {
       console.log(row.join(' '))
     }
 
+    const storedEnc = stored[0]
+    assertSteVec(storedEnc)
+
     // EQL v2.3: SteVec storage has sv (root ciphertext lives at sv[0].c, not the root).
-    expect(stored[0]).not.toHaveProperty('c')
-    expect(stored[0]).toHaveProperty('sv')
-    expect(stored[0].sv?.[0]).toHaveProperty('c')
+    expect(storedEnc).not.toHaveProperty('c')
+    expect(storedEnc).toHaveProperty('sv')
+    expect(storedEnc.sv?.[0]).toHaveProperty('c')
 
     // Selector query should have s (selector) but not c
     expect(querySelector[0]).toHaveProperty('s')
@@ -718,6 +729,9 @@ describe('type inference equivalence', () => {
     expect(inferred).toHaveProperty('v')
     expect(explicit).toHaveProperty('v')
 
+    assertSteVec(inferred)
+    assertSteVec(explicit)
+
     // Identifier should match (same table/column)
     expect(inferred.i).toEqual(explicit.i)
 
@@ -753,6 +767,9 @@ describe('type inference equivalence', () => {
     expect(explicit).toHaveProperty('s')
     expect(inferred).not.toHaveProperty('c')
     expect(explicit).not.toHaveProperty('c')
+
+    assertSteVec(inferred)
+    assertSteVec(explicit)
 
     // Identifier should match
     expect(inferred.i).toEqual(explicit.i)
@@ -825,6 +842,7 @@ describe('type inference with nested structures', () => {
     expect(result).toHaveProperty('v')
     expect(result).not.toHaveProperty('c')
     expect(result).toHaveProperty('sv')
+    assertSteVec(result)
     expect(result.sv?.[0]).toHaveProperty('c')
   })
 })

--- a/integration-tests/tests/json.test.ts
+++ b/integration-tests/tests/json.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@cipherstash/protect-ffi'
 
 // Import shared encryptConfig from common.js
-import { jsonOpaque, jsonSteVec } from './common.js'
+import { assertSteVec, jsonOpaque, jsonSteVec } from './common.js'
 
 type UserColumn = Identifier<typeof jsonOpaque>
 
@@ -116,6 +116,7 @@ describe('SteVec output structure', () => {
 
     // SteVec variant must have these fields
     expect(ciphertext.k).toBe('sv')
+    assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(ciphertext).toHaveProperty('sv')
     expect(ciphertext).toHaveProperty('i')
@@ -124,11 +125,10 @@ describe('SteVec output structure', () => {
     expect(ciphertext).not.toHaveProperty('c')
 
     // Validate entry structure uses new field names
-    const encrypted = ciphertext as { sv: unknown[] }
-    expect(Array.isArray(encrypted.sv)).toBe(true)
-    expect(encrypted.sv.length).toBeGreaterThan(0)
+    expect(Array.isArray(ciphertext.sv)).toBe(true)
+    expect(ciphertext.sv?.length ?? 0).toBeGreaterThan(0)
 
-    const entry = encrypted.sv[0] as Record<string, unknown>
+    const entry = ciphertext.sv?.[0]
     expect(entry).toHaveProperty('c') // Entry ciphertext (new format)
     expect(entry).toHaveProperty('s') // Tokenized selector
 
@@ -151,11 +151,12 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as { sv: Array<{ s?: string; c: string }> }
+      const sv = ciphertext.sv ?? []
 
       // At least one entry should have a selector
-      const entriesWithSelector = encrypted.sv.filter((e) => e.s !== undefined)
+      const entriesWithSelector = sv.filter((e) => e.s !== undefined)
       expect(entriesWithSelector.length).toBeGreaterThan(0)
 
       // Selector should be hex encoded
@@ -175,11 +176,12 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as { sv: Array<{ a?: boolean; c: string }> }
+      const sv = ciphertext.sv ?? []
 
       // With default ArrayIndexMode (NONE), array items should not have a: true
-      const arrayEntries = encrypted.sv.filter((e) => e.a === true)
+      const arrayEntries = sv.filter((e) => e.a === true)
       expect(arrayEntries.length).toBe(0)
     })
 
@@ -192,11 +194,11 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as { sv: Array<{ a?: boolean; c: string }> }
 
       // Non-array items should not have a: true
-      for (const entry of encrypted.sv) {
+      for (const entry of ciphertext.sv ?? []) {
         expect(entry.a).not.toBe(true)
       }
     })
@@ -217,12 +219,11 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as {
-        sv: Array<{ hm?: string; oc?: string; c: string }>
-      }
+      const sv = ciphertext.sv ?? []
 
-      const entriesWithOre = encrypted.sv.filter((e) => e.oc !== undefined)
+      const entriesWithOre = sv.filter((e) => e.oc !== undefined)
       expect(entriesWithOre.length).toBeGreaterThan(0)
 
       for (const entry of entriesWithOre) {
@@ -239,12 +240,11 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as {
-        sv: Array<{ hm?: string; oc?: string; c: string }>
-      }
+      const sv = ciphertext.sv ?? []
 
-      const entriesWithOre = encrypted.sv.filter((e) => e.oc !== undefined)
+      const entriesWithOre = sv.filter((e) => e.oc !== undefined)
       expect(entriesWithOre.length).toBeGreaterThan(0)
 
       for (const entry of entriesWithOre) {
@@ -265,10 +265,11 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as { sv: Array<{ hm?: string; c: string }> }
+      const sv = ciphertext.sv ?? []
 
-      const entriesWithHm = encrypted.sv.filter((e) => e.hm !== undefined)
+      const entriesWithHm = sv.filter((e) => e.hm !== undefined)
       expect(entriesWithHm.length).toBeGreaterThan(0)
 
       for (const entry of entriesWithHm) {
@@ -285,10 +286,11 @@ describe('SteVec index field generation', () => {
         column: 'profile',
       })
 
+      assertSteVec(ciphertext)
       expect(ciphertext.sv).toBeDefined()
-      const encrypted = ciphertext as { sv: Array<{ hm?: string; c: string }> }
+      const sv = ciphertext.sv ?? []
 
-      const entriesWithHm = encrypted.sv.filter((e) => e.hm !== undefined)
+      const entriesWithHm = sv.filter((e) => e.hm !== undefined)
       expect(entriesWithHm.length).toBeGreaterThan(0)
 
       for (const entry of entriesWithHm) {
@@ -319,6 +321,7 @@ describe('deeply nested JSON encryption', () => {
     })
 
     // Verify sv structure exists for nested JSON
+    assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)
     expect(ciphertext.sv?.length).toBeGreaterThan(0)
@@ -341,6 +344,7 @@ describe('deeply nested JSON encryption', () => {
     })
 
     // Verify sv structure for nested arrays
+    assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)
 
@@ -374,6 +378,7 @@ describe('deeply nested JSON encryption', () => {
     })
 
     // Verify sv structure for mixed nested content
+    assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)
     expect(ciphertext.sv?.length).toBeGreaterThan(0)

--- a/integration-tests/tests/json.test.ts
+++ b/integration-tests/tests/json.test.ts
@@ -114,8 +114,6 @@ describe('SteVec output structure', () => {
       column: 'profile',
     })
 
-    // SteVec variant must have these fields
-    expect(ciphertext.k).toBe('sv')
     assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(ciphertext).toHaveProperty('sv')
@@ -320,7 +318,6 @@ describe('deeply nested JSON encryption', () => {
       column: 'profile',
     })
 
-    // Verify sv structure exists for nested JSON
     assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)
@@ -343,7 +340,6 @@ describe('deeply nested JSON encryption', () => {
       column: 'profile',
     })
 
-    // Verify sv structure for nested arrays
     assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)
@@ -377,7 +373,6 @@ describe('deeply nested JSON encryption', () => {
       column: 'profile',
     })
 
-    // Verify sv structure for mixed nested content
     assertSteVec(ciphertext)
     expect(ciphertext.sv).toBeDefined()
     expect(Array.isArray(ciphertext.sv)).toBe(true)

--- a/integration-tests/tests/query.test.ts
+++ b/integration-tests/tests/query.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@cipherstash/protect-ffi'
 
 // Import shared encryptConfig from common.js
-import { encryptConfig } from './common.js'
+import { assertScalar, assertSteVec, encryptConfig } from './common.js'
 
 type UserColumn = Identifier<typeof encryptConfig>
 
@@ -85,6 +85,7 @@ describe('encryptQuery for ste_vec indexes', () => {
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
     expect(result.k).toBe('sv')
+    assertSteVec(result)
     expect(result).toHaveProperty('sv') // Flattened entries for containment matching
     expect(Array.isArray(result.sv)).toBe(true)
     expect(result).not.toHaveProperty('c')
@@ -123,6 +124,7 @@ describe('encryptQuery for string indexes', () => {
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
     expect(result).toHaveProperty('ob') // ORE blocks for range queries
+    assertScalar(result)
     expect(Array.isArray(result.ob)).toBe(true)
   })
 
@@ -139,6 +141,7 @@ describe('encryptQuery for string indexes', () => {
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
     expect(result).toHaveProperty('bf') // bloom filter for fuzzy/substring match
+    assertScalar(result)
     expect(Array.isArray(result.bf)).toBe(true)
   })
 
@@ -155,6 +158,7 @@ describe('encryptQuery for string indexes', () => {
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
     expect(result).toHaveProperty('hm') // HMAC for exact match queries
+    assertScalar(result)
     expect(typeof result.hm).toBe('string')
   })
 })
@@ -173,6 +177,7 @@ describe('encryptQuery for numeric indexes', () => {
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
     expect(result).toHaveProperty('ob') // ORE blocks for range queries
+    assertScalar(result)
     expect(Array.isArray(result.ob)).toBe(true)
   })
 })
@@ -330,6 +335,9 @@ describe('encryptQueryBulk for query ordering and grouping', () => {
     expect(results[0]).toHaveProperty('hm')
     expect(results[1]).toHaveProperty('hm')
     expect(results[2]).toHaveProperty('hm')
+    assertScalar(results[0])
+    assertScalar(results[1])
+    assertScalar(results[2])
     // Results should be different (different plaintexts)
     expect(results[0].hm).not.toEqual(results[1].hm)
     expect(results[1].hm).not.toEqual(results[2].hm)

--- a/integration-tests/tests/query.test.ts
+++ b/integration-tests/tests/query.test.ts
@@ -84,7 +84,6 @@ describe('encryptQuery for ste_vec indexes', () => {
     // Under EQL v2.3 the root ciphertext lives at sv[0].c, not at the root.
     expect(result).toHaveProperty('i')
     expect(result).toHaveProperty('v')
-    expect(result.k).toBe('sv')
     assertSteVec(result)
     expect(result).toHaveProperty('sv') // Flattened entries for containment matching
     expect(Array.isArray(result.sv)).toBe(true)

--- a/integration-tests/tests/scalar.test.ts
+++ b/integration-tests/tests/scalar.test.ts
@@ -187,7 +187,6 @@ describe('EQL v2.3 wire format', () => {
       column: 'profile',
     })
 
-    expect(ciphertext.k).toBe('sv')
     assertSteVec(ciphertext)
     expect(ciphertext).toHaveProperty('sv')
     // SteVec payloads place the root ciphertext at sv[0].c, not at the root.

--- a/integration-tests/tests/scalar.test.ts
+++ b/integration-tests/tests/scalar.test.ts
@@ -10,7 +10,12 @@ import {
 } from '@cipherstash/protect-ffi'
 
 // Import shared configs from common.js
-import { encryptConfig, jsonSteVec } from './common.js'
+import {
+  assertScalar,
+  assertSteVec,
+  encryptConfig,
+  jsonSteVec,
+} from './common.js'
 
 type UserColumn = Identifier<typeof encryptConfig>
 
@@ -183,6 +188,7 @@ describe('EQL v2.3 wire format', () => {
     })
 
     expect(ciphertext.k).toBe('sv')
+    assertSteVec(ciphertext)
     expect(ciphertext).toHaveProperty('sv')
     // SteVec payloads place the root ciphertext at sv[0].c, not at the root.
     expect(ciphertext).not.toHaveProperty('c')
@@ -200,6 +206,7 @@ describe('encrypted output SEM fields', () => {
       column: 'email', // has unique: {} index
     })
 
+    assertScalar(ciphertext)
     // hm = HMAC for exact match queries
     expect(ciphertext.hm).toBeDefined()
     expect(typeof ciphertext.hm).toBe('string')
@@ -215,6 +222,7 @@ describe('encrypted output SEM fields', () => {
       column: 'score', // has ore: {} index
     })
 
+    assertScalar(ciphertext)
     // ob = ORE blocks for range queries
     expect(ciphertext.ob).toBeDefined()
     expect(Array.isArray(ciphertext.ob)).toBe(true)
@@ -230,6 +238,7 @@ describe('encrypted output SEM fields', () => {
       column: 'email', // has match: {} index
     })
 
+    assertScalar(ciphertext)
     // bf = bloom filter for fuzzy/substring match queries
     expect(ciphertext.bf).toBeDefined()
     expect(Array.isArray(ciphertext.bf)).toBe(true)
@@ -245,6 +254,7 @@ describe('encrypted output SEM fields', () => {
       column: 'email', // has ore, match, and unique indexes
     })
 
+    assertScalar(ciphertext)
     // email column has all three index types
     expect(ciphertext.hm).toBeDefined() // unique
     expect(ciphertext.ob).toBeDefined() // ore

--- a/src/index.cts
+++ b/src/index.cts
@@ -289,24 +289,34 @@ export type EncryptedScalar = {
   ob?: string[]
 }
 
-/** STE-vector EQL v2.3 payload (`k: "sv"`). */
-export type EncryptedSteVec = {
+/**
+ * STE-vector EQL v2.3 payload (`k: "sv"`). The FFI emits two disjoint shapes:
+ *
+ * - {@link EncryptedSteVecStorage} for storage encryption and JSON containment
+ *   queries — carries a non-empty `sv` with the root ciphertext at `sv[0].c`.
+ * - {@link EncryptedSteVecSelector} for `ste_vec_selector` queries — carries
+ *   only a tokenized selector `s`.
+ */
+export type EncryptedSteVec = EncryptedSteVecStorage | EncryptedSteVecSelector
+
+/** SteVec storage payload (also used for containment queries). */
+export type EncryptedSteVecStorage = {
   k: 'sv'
-  /** EQL schema version */
   v: number
-  /** Table and column identifier */
   i: { t: string; c: string }
-  /**
-   * Per-selector SteVec entries. Present on SteVec storage payloads and on
-   * JSON containment queries (which the FFI emits as storage payloads). The
-   * root document ciphertext lives at `sv[0].c`. Absent on selector queries.
-   */
-  sv?: SteVecEntry[]
-  /**
-   * Tokenized selector for `ste_vec_selector` queries. Present only on
-   * selector query payloads; absent on storage / containment payloads.
-   */
-  s?: string
+  /** Per-selector entries; root document ciphertext lives at `sv[0].c`. */
+  sv: [SteVecEntry, ...SteVecEntry[]]
+  s?: never
+}
+
+/** SteVec selector query payload (`ste_vec_selector`). */
+export type EncryptedSteVecSelector = {
+  k: 'sv'
+  v: number
+  i: { t: string; c: string }
+  /** Tokenized selector for path queries. */
+  s: string
+  sv?: never
 }
 
 /**

--- a/src/index.cts
+++ b/src/index.cts
@@ -252,37 +252,61 @@ export type Context = {
 /**
  * Represents an EQL v2.3 payload returned by the FFI.
  *
- * This TypeScript type mirrors the Rust `EqlCiphertext` enum from `cipherstash-client`,
- * which is a discriminated union keyed on `k`:
- * - `k: "ct"` — scalar payload with root-scope index terms (`c`, `hm`, `bf`, `ob`).
- *   Storage payloads always carry `c`; query payloads omit `c`.
- * - `k: "sv"` — STE-vector payload with per-selector entries in `sv`.
- *   Storage payloads carry the root ciphertext at `sv[0].c`; query payloads
- *   carry either a single selector (`s`) or a containment vector (`q`).
+ * Discriminated union keyed on `k`. Narrow on `k` before accessing variant-only
+ * fields:
+ *
+ * ```ts
+ * if (payload.k === 'sv') {
+ *   payload.sv?.forEach(...)
+ * }
+ * ```
+ *
+ * - `k: "ct"` — scalar payload (storage or query for `unique` / `match` / `ore`
+ *   indexes). Storage payloads always carry `c`; query payloads omit `c` and
+ *   carry exactly one of `hm`, `bf`, or `ob`.
+ * - `k: "sv"` — STE-vector payload. The FFI emits this for SteVec storage
+ *   *and* for JSON containment queries (`ste_vec_term`), both of which carry
+ *   per-selector entries in `sv` with the root document ciphertext at
+ *   `sv[0].c`. Selector queries (`ste_vec_selector`) instead carry a single
+ *   tokenized selector `s` and omit `sv`.
  */
-export type Encrypted = {
-  /** EQL v2.3 root discriminator — `"ct"` for scalar, `"sv"` for STE-vector */
-  k: 'ct' | 'sv'
-  /** The encryption version */
+export type Encrypted = EncryptedScalar | EncryptedSteVec
+
+/** Scalar EQL v2.3 payload (`k: "ct"`). */
+export type EncryptedScalar = {
+  k: 'ct'
+  /** EQL schema version */
   v: number
-  /** The table and column identifier */
+  /** Table and column identifier */
   i: { t: string; c: string }
-  /** Encrypted ciphertext (mp_base85). Present on scalar storage payloads; absent on scalar queries. */
+  /** Encrypted ciphertext (mp_base85). Required on storage payloads; absent on query payloads. */
   c?: string
-  /** HMAC-SHA256 hash for exact-match equality (unique index) */
+  /** HMAC-SHA256 hash — `unique` index term on storage, or `unique` lookup term on queries. */
   hm?: string
-  /** Bloom filter (set bit positions) for LIKE / ILIKE (match index) */
+  /** Bloom filter (set bit positions) — `match` index term on storage, or `match` lookup term on queries. */
   bf?: number[]
-  /** Block ORE u64_8_256 term for ordered comparisons (ore index) */
+  /** Block ORE u64_8_256 term — `ore` index term on storage, or `ore` comparison term on queries. */
   ob?: string[]
-  /** Per-selector SteVec entries (present on `k:"sv"` storage payloads) */
+}
+
+/** STE-vector EQL v2.3 payload (`k: "sv"`). */
+export type EncryptedSteVec = {
+  k: 'sv'
+  /** EQL schema version */
+  v: number
+  /** Table and column identifier */
+  i: { t: string; c: string }
+  /**
+   * Per-selector SteVec entries. Present on SteVec storage payloads and on
+   * JSON containment queries (which the FFI emits as storage payloads). The
+   * root document ciphertext lives at `sv[0].c`. Absent on selector queries.
+   */
   sv?: SteVecEntry[]
-  /** Tokenized selector for `ste_vec_selector` queries (present on `k:"sv"` query payloads) */
+  /**
+   * Tokenized selector for `ste_vec_selector` queries. Present only on
+   * selector query payloads; absent on storage / containment payloads.
+   */
   s?: string
-  /** CLLW ORE term for `ste_vec_term` queries (present on `k:"sv"` query payloads) */
-  oc?: string
-  /** Full STE query vector for JSON containment queries (present on `k:"sv"` containment queries) */
-  q?: unknown
 }
 
 /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Refactored encrypted payload TypeScript types into a discriminated union, providing clearer shape differentiation between scalar and vector-based ciphertexts.

* **Documentation**
  * Updated JSONB API reference to clarify query payload structures and specify encryption format variants for different query types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/protectjs-ffi/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->