### PR TITLE
feat: accept opts.strategy on both Node and WASM newClient

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,16 @@ jobs:
         shell: bash
         run: cargo check --target wasm32-unknown-unknown -p protect-ffi
 
+      # The `mise run test:integration:all` step below builds wasm artifacts
+      # because `tests/wasm-round-trip.test.ts` loads
+      # `dist/wasm/protect_ffi_inline.js` at module-graph time. Pinned to
+      # the same version used by the build workflow.
+      - name: Install wasm-pack
+        uses: baptiste0928/cargo-install@c7dafcfd8a0035d58dfc65d0fbaf71a9ac347715 # v2
+        with:
+          crate: wasm-pack
+          version: '0.13.1'
+
       - name: Rust Lint
         run: mise lint:rust
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,6 +286,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "base85"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,9 +549,8 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0257cff25a25a706af6e190e5209865aae4ddf0b36f81febee7de014b22bcc40"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -553,6 +558,7 @@ dependencies = [
  "async-trait",
  "base16ct",
  "base64",
+ "base64ct",
  "base85",
  "blake3",
  "chrono",
@@ -603,9 +609,8 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376d237e368e77de53b07bb7309812f45809299063c80b6cc3132f7d8494aed"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "bitflags",
  "serde",
@@ -615,9 +620,8 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-core"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca84ffd8a7b2f0c8c6b04eba600738fea115f5a4ed825035a2f13aa1524085a7"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "getrandom 0.2.17",
  "hmac",
@@ -632,8 +636,7 @@ dependencies = [
 [[package]]
 name = "cllw-ore"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f73a23cbc15404d9b314c03b16a888f798dbc681bceeb2e18674f602f9da02d"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "blake3",
  "chrono",
@@ -834,9 +837,8 @@ dependencies = [
 
 [[package]]
 name = "cts-common"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6508011dee61bc36e16615e43cb26a8014c49ebb832e713602f3b0dc15af29"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "arrayvec",
  "base32",
@@ -2651,8 +2653,7 @@ dependencies = [
 [[package]]
 name = "recipher"
 version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9398dce78ddfce08f93e9d9a3ac64d9b0a4fed478c0a82003c6e4c90dc245125"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "aes",
  "cmac",
@@ -3266,9 +3267,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stack-auth"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c823cc3d88e15478d51694ef56037400bd4ae3e1a9e046071e01d251168cc466"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "aquamarine",
  "base64",
@@ -3294,9 +3294,8 @@ dependencies = [
 
 [[package]]
 name = "stack-profile"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1be30119d59260f3e932f78fbbfbe3674c151d39e7fcca24d0439e7e31ba8"
+version = "0.36.0"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4869,9 +4868,8 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04a9411f442b247e7d00c6a07cfbc6d56c12d485cfaf4f7effa001bfb1615296"
+version = "0.12.16"
+source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
 dependencies = [
  "base64",
  "cipherstash-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,7 +550,8 @@ dependencies = [
 [[package]]
 name = "cipherstash-client"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6b9666c5397e1feeabe3f0212446ff362d27fc2062c9d12807c7400fb83f3c"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -610,7 +611,8 @@ dependencies = [
 [[package]]
 name = "cipherstash-config"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b9f36a62fdb1abf225c1072d460d22fff4da4deebe0781ff1ecbee3261e0cff"
 dependencies = [
  "bitflags",
  "serde",
@@ -621,7 +623,8 @@ dependencies = [
 [[package]]
 name = "cipherstash-core"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1a3f1483fd420059935764fea971869f39a6e025edf10cfb2a2ca7594ac2b8"
 dependencies = [
  "getrandom 0.2.17",
  "hmac",
@@ -636,7 +639,8 @@ dependencies = [
 [[package]]
 name = "cllw-ore"
 version = "0.4.2"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f73a23cbc15404d9b314c03b16a888f798dbc681bceeb2e18674f602f9da02d"
 dependencies = [
  "blake3",
  "chrono",
@@ -838,7 +842,8 @@ dependencies = [
 [[package]]
 name = "cts-common"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d924055250a6dcd4a67a490e9bf9fe26dff9ab8b40ab5f4a60a3e6e03569b0e"
 dependencies = [
  "arrayvec",
  "base32",
@@ -2653,7 +2658,8 @@ dependencies = [
 [[package]]
 name = "recipher"
 version = "0.2.3"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9398dce78ddfce08f93e9d9a3ac64d9b0a4fed478c0a82003c6e4c90dc245125"
 dependencies = [
  "aes",
  "cmac",
@@ -3268,7 +3274,8 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 [[package]]
 name = "stack-auth"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88c95d236e8c5e48d89ff181af6b0bcff2519d65f455563aff762c0ab80dbb63"
 dependencies = [
  "aquamarine",
  "base64",
@@ -3295,7 +3302,8 @@ dependencies = [
 [[package]]
 name = "stack-profile"
 version = "0.36.0"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7384df859a75bf6b282fbd8ddad139abffa28a4d128dce402f8ee4130815f2"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4869,7 +4877,8 @@ dependencies = [
 [[package]]
 name = "zerokms-protocol"
 version = "0.12.16"
-source = "git+https://github.com/cipherstash/cipherstash-suite?branch=release-plz-2026-05-25T06-51-46Z#8381d9e5f3dcabb8031ebc41ca30fa6f1647010b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f279d7e22849e3b5f3e3809a3b77ee36456e1bb35190eb494a564c2a94e4454"
 dependencies = [
  "base64",
  "cipherstash-config",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
-cipherstash-client = { version = "=0.35.0", features = ["tokio"] }
-cts-common = { version = "=0.35.0", default-features = false }
-stack-auth = { version = "=0.35.0" }
+cipherstash-client = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z", features = ["tokio"] }
+cts-common = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z", default-features = false }
+stack-auth = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z" }
 hex = "0.4.3"
 once_cell = "1.20.2"
 rust_decimal = "1.37"
@@ -25,7 +25,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 neon = { version = "1", features = ["serde", "tokio"] }
-stack-profile = { version = "=0.35.0" }
+stack-profile = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
-cipherstash-client = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z", features = ["tokio"] }
-cts-common = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z", default-features = false }
-stack-auth = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z" }
+cipherstash-client = { version = "=0.36.0", features = ["tokio"] }
+cts-common = { version = "=0.36.0", default-features = false }
+stack-auth = { version = "=0.36.0" }
 hex = "0.4.3"
 once_cell = "1.20.2"
 rust_decimal = "1.37"
@@ -25,7 +25,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 neon = { version = "1", features = ["serde", "tokio"] }
-stack-profile = { git = "https://github.com/cipherstash/cipherstash-suite", branch = "release-plz-2026-05-25T06-51-46Z" }
+stack-profile = { version = "=0.36.0" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -312,16 +312,38 @@ impl NeonJsAuthStrategy {
         // into the JS-thread closure, unref it there (which requires a
         // `Cx`), and return it back to be stored on `self`.
         let sender = channel.clone();
-        let (get_token, channel) = sender
+        // Retrieve the property as a raw JsValue and do an explicit
+        // `is_a` + `downcast` check, so a missing or non-callable
+        // `getToken` becomes a clean `Result::Err` rather than a `Throw`
+        // bubbling through the channel callback (which surfaces as an
+        // unhandled rejection on the JS side even when the Rust caller
+        // catches the resulting JoinError).
+        let lookup: Result<(Root<JsFunction>, Channel), String> = sender
             .send(move |mut cx| {
                 let mut channel = channel;
                 let obj = strategy_for_lookup.to_inner(&mut cx);
-                let func: Handle<JsFunction> = obj.prop(&mut cx, "getToken").get()?;
+                let raw: Handle<JsValue> = obj.prop(&mut cx, "getToken").get()?;
+                if raw.is_a::<JsUndefined, _>(&mut cx) || raw.is_a::<JsNull, _>(&mut cx) {
+                    channel.unref(&mut cx);
+                    return Ok(Err(
+                        "opts.strategy.getToken is missing".to_string()
+                    ));
+                }
+                let func = match raw.downcast::<JsFunction, _>(&mut cx) {
+                    Ok(f) => f,
+                    Err(_) => {
+                        channel.unref(&mut cx);
+                        return Ok(Err(
+                            "opts.strategy.getToken is not a function".to_string()
+                        ));
+                    }
+                };
                 channel.unref(&mut cx);
-                Ok((func.root(&mut cx), channel))
+                Ok(Ok((func.root(&mut cx), channel)))
             })
             .await
             .map_err(|e| Error::Credentials(format!("strategy.getToken lookup failed: {e}")))?;
+        let (get_token, channel) = lookup.map_err(Error::Credentials)?;
         Ok(Self {
             strategy,
             get_token: Arc::new(get_token),

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -25,8 +25,15 @@ use js_plaintext::JsPlaintext;
 #[cfg(not(target_arch = "wasm32"))]
 use neon::{
     prelude::*,
-    types::extract::{Boxed, Json},
+    types::{
+        extract::{Boxed, Json},
+        JsFuture,
+    },
 };
+#[cfg(not(target_arch = "wasm32"))]
+use stack_auth::{AuthStrategy, SecretToken};
+#[cfg(not(target_arch = "wasm32"))]
+use std::future::Future;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -43,10 +50,11 @@ extern crate quickcheck;
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 struct Client {
     cipher: Arc<ScopedZeroKMS>,
-    zerokms: Arc<ZeroKMSWithClientKey<AutoStrategy>>,
+    zerokms: Arc<ZeroKMSWithClientKey<NodeAuthStrategy>>,
     encrypt_config: Arc<HashMap<Identifier, ColumnConfig>>,
 }
 
@@ -269,7 +277,135 @@ pub enum Error {
     Config(#[from] ConfigError),
 }
 
-type ScopedZeroKMS = ScopedCipher<AutoStrategy>;
+/// JS-backed [`AuthStrategy`] for the Neon build.
+///
+/// Holds the strategy object and its `getToken` callable as Neon [`Root`]s,
+/// plus a [`Channel`] for invoking them from tokio tasks. Mirrors
+/// `wasm::JsAuthStrategy` but uses Neon's cross-thread invocation model
+/// instead of wasm's single-threaded one.
+///
+/// `getToken()` is called on every ZeroKMS request — caching is the JS
+/// strategy's responsibility, matching the wasm path.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct NeonJsAuthStrategy {
+    strategy: Arc<Root<JsObject>>,
+    get_token: Arc<Root<JsFunction>>,
+    channel: Channel,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl NeonJsAuthStrategy {
+    /// Build from a JS strategy object. Looks up `getToken` on the object
+    /// via the shared [`JS_CHANNEL`] so the result is a stable [`Root`] we
+    /// can call from any tokio task.
+    async fn from_root(strategy: Root<JsObject>) -> Result<Self, Error> {
+        let channel = JS_CHANNEL
+            .get()
+            .ok_or_else(|| Error::Credentials("module not initialized".to_string()))?
+            .clone();
+        let strategy = Arc::new(strategy);
+        let strategy_for_lookup = Arc::clone(&strategy);
+        let get_token = channel
+            .send(move |mut cx| {
+                let obj = strategy_for_lookup.to_inner(&mut cx);
+                let func: Handle<JsFunction> = obj.prop(&mut cx, "getToken").get()?;
+                Ok(func.root(&mut cx))
+            })
+            .await
+            .map_err(|e| {
+                Error::Credentials(format!("strategy.getToken lookup failed: {e}"))
+            })?;
+        Ok(Self {
+            strategy,
+            get_token: Arc::new(get_token),
+            channel,
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AuthStrategy for &NeonJsAuthStrategy {
+    fn get_token(self) -> impl Future<Output = Result<stack_auth::ServiceToken, AuthError>> + Send {
+        let strategy = Arc::clone(&self.strategy);
+        let get_token = Arc::clone(&self.get_token);
+        let channel = self.channel.clone();
+        async move {
+            // Schedule the JS call on the JS thread. The closure returns a
+            // `JsFuture<Result<String, String>>`: outer Result distinguishes
+            // a resolved token (Ok) from a structurally-bad result or a
+            // rejection (Err); inner type carries the token string.
+            let js_future: JsFuture<Result<String, String>> = channel
+                .send(move |mut cx| {
+                    let strategy_h = strategy.to_inner(&mut cx);
+                    let func_h = get_token.to_inner(&mut cx);
+                    let args: [Handle<JsValue>; 0] = [];
+                    let result = func_h.call(&mut cx, strategy_h, args)?;
+                    let promise: Handle<JsPromise> = result.downcast_or_throw(&mut cx)?;
+                    promise.to_future(&mut cx, |mut cx, settled| match settled {
+                        Ok(v) => {
+                            let obj = match v.downcast::<JsObject, _>(&mut cx) {
+                                Ok(o) => o,
+                                Err(_) => {
+                                    return Ok(Err(
+                                        "strategy.getToken did not return an object".to_string(),
+                                    ))
+                                }
+                            };
+                            let token: Handle<JsString> =
+                                match obj.prop(&mut cx, "token").get() {
+                                    Ok(t) => t,
+                                    Err(_) => return Ok(Err("missing 'token' field".to_string())),
+                                };
+                            Ok(Ok(token.value(&mut cx)))
+                        }
+                        Err(err) => {
+                            let msg = err
+                                .to_string(&mut cx)
+                                .map(|s| s.value(&mut cx))
+                                .unwrap_or_else(|_| "strategy.getToken rejected".to_string());
+                            Ok(Err(msg))
+                        }
+                    })
+                })
+                .await
+                .map_err(|e| AuthError::Server(format!("strategy callback failed: {e}")))?;
+
+            let token_result = js_future
+                .await
+                .map_err(|e| AuthError::Server(format!("strategy promise await failed: {e}")))?;
+
+            match token_result {
+                Ok(s) => Ok(stack_auth::ServiceToken::new(SecretToken::new(s))),
+                Err(msg) => Err(AuthError::Server(msg)),
+            }
+        }
+    }
+}
+
+/// Auth strategy held by the Neon-side [`Client`]. Either the
+/// filesystem/env-backed [`AutoStrategy`] (built from credentials in opts
+/// or the profile store) or a [`NeonJsAuthStrategy`] supplied by the
+/// caller via `opts.strategy`.
+#[cfg(not(target_arch = "wasm32"))]
+enum NodeAuthStrategy {
+    Auto(AutoStrategy),
+    JsBacked(NeonJsAuthStrategy),
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AuthStrategy for &NodeAuthStrategy {
+    fn get_token(self) -> impl Future<Output = Result<stack_auth::ServiceToken, AuthError>> + Send {
+        async move {
+            match self {
+                NodeAuthStrategy::Auto(s) => s.get_token().await,
+                NodeAuthStrategy::JsBacked(s) => s.get_token().await,
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type ScopedZeroKMS = ScopedCipher<NodeAuthStrategy>;
 
 /// Credential fields shared by [`ClientOpts`] and [`EnsureKeysetOpts`].
 #[derive(Deserialize, Default)]
@@ -730,11 +866,15 @@ fn to_query_plaintext(
 #[neon::export]
 pub async fn new_client(
     Json(opts): Json<NewClientOptions>,
+    strategy: Option<Root<JsObject>>,
 ) -> Result<Boxed<Client>, neon::types::extract::Error> {
     let client_opts = opts.client_opts.unwrap_or_default();
 
-    let strategy = client_opts.creds.build_strategy()?;
-    let zerokms = ZeroKMSBuilder::new(strategy)
+    let auth = match strategy {
+        Some(s) => NodeAuthStrategy::JsBacked(NeonJsAuthStrategy::from_root(s).await?),
+        None => NodeAuthStrategy::Auto(client_opts.creds.build_strategy()?),
+    };
+    let zerokms = ZeroKMSBuilder::new(auth)
         .with_key_provider(client_opts.creds.build_key_provider()?)
         .build()
         .await?;
@@ -1278,6 +1418,12 @@ fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
 #[cfg(not(target_arch = "wasm32"))]
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
+/// Channel captured at module init so [`NeonJsAuthStrategy`] can invoke
+/// JS callables from tokio tasks without threading a `Cx` through every
+/// call site.
+#[cfg(not(target_arch = "wasm32"))]
+static JS_CHANNEL: OnceCell<Channel> = OnceCell::new();
+
 #[cfg(not(target_arch = "wasm32"))]
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
@@ -1286,6 +1432,7 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         .or_else(|err| cx.throw_error(err.to_string()))?;
 
     let _ = neon::set_global_executor(&mut cx, runtime);
+    let _ = JS_CHANNEL.set(cx.channel());
 
     neon::registered().export(&mut cx)?;
 

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -3,7 +3,6 @@ mod js_plaintext;
 mod wasm;
 
 use cipherstash_client::{
-    credentials::ServiceToken,
     encryption::{EncryptionError, Plaintext, QueryOp, ScopedCipher, TypeParseError},
     eql::{
         encrypt_eql, EqlCiphertext, EqlEncryptOpts, EqlError, EqlOperation, EqlOutput,
@@ -504,7 +503,6 @@ struct EncryptOptions {
     column: String,
     table: String,
     lock_context: Option<LockContext>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -512,7 +510,6 @@ struct EncryptOptions {
 #[serde(rename_all = "camelCase")]
 struct EncryptBulkOptions {
     plaintexts: Vec<PlaintextPayload>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -540,7 +537,6 @@ struct EncryptQueryOptions {
     #[serde(default = "default_query_op")]
     query_op: String,
     lock_context: Option<LockContext>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -553,7 +549,6 @@ fn default_query_op() -> String {
 #[serde(rename_all = "camelCase")]
 struct EncryptQueryBulkOptions {
     queries: Vec<QueryPayload>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -575,7 +570,6 @@ struct QueryPayload {
 struct DecryptOptions {
     ciphertext: Encrypted,
     lock_context: Option<LockContext>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -583,7 +577,6 @@ struct DecryptOptions {
 #[serde(rename_all = "camelCase")]
 struct DecryptBulkOptions {
     ciphertexts: Vec<BulkDecryptPayload>,
-    service_token: Option<ServiceToken>,
     unverified_context: Option<UnverifiedContext>,
 }
 
@@ -968,7 +961,6 @@ async fn encrypt(
     let eql_opts = EqlEncryptOpts {
         keyset_id: None, // Use cipher's default
         lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
-        service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
         decryption_policy: None,
@@ -1041,7 +1033,6 @@ async fn encrypt_bulk(
         let eql_opts = EqlEncryptOpts {
             keyset_id: None,
             lock_context: Cow::Owned(lock_context),
-            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
             decryption_policy: None,
@@ -1113,7 +1104,6 @@ async fn encrypt_query(
     let eql_opts = EqlEncryptOpts {
         keyset_id: None,
         lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
-        service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
         decryption_policy: None,
@@ -1196,7 +1186,6 @@ async fn encrypt_query_bulk(
         let eql_opts = EqlEncryptOpts {
             keyset_id: None,
             lock_context: Cow::Owned(lock_context),
-            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
             decryption_policy: None,
@@ -1237,7 +1226,6 @@ async fn decrypt(
             encrypted_record,
             // Specifying None here will result in the client using the keyset identifier from the client
             None,
-            opts.service_token.map(Cow::Owned),
             opts.unverified_context.as_ref(),
         )
         .await
@@ -1277,7 +1265,6 @@ async fn decrypt_bulk(
             encrypted_records,
             // Specifying None here will result in the client using the keyset identifier from the client
             None,
-            opts.service_token.map(Cow::Owned),
             opts.unverified_context.as_ref(),
         )
         .await?;
@@ -1328,11 +1315,7 @@ async fn decrypt_bulk_fallible(
 
     let decrypted: Vec<Result<Vec<u8>, RecordDecryptError>> = client
         .zerokms
-        .decrypt_fallible(
-            valid_records,
-            opts.service_token.map(Cow::Owned),
-            opts.unverified_context.map(Cow::Owned),
-        )
+        .decrypt_fallible(valid_records, opts.unverified_context.map(Cow::Owned))
         .await?;
 
     for (item, idx) in decrypted.into_iter().zip(valid_indices) {

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -292,14 +292,13 @@ pub(crate) struct NeonJsAuthStrategy {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl NeonJsAuthStrategy {
-    /// Build from a JS strategy object. Looks up `getToken` on the object
-    /// via the shared [`JS_CHANNEL`] so the result is a stable [`Root`] we
-    /// can call from any tokio task.
-    async fn from_root(strategy: Root<JsObject>) -> Result<Self, Error> {
-        let channel = JS_CHANNEL
-            .get()
-            .ok_or_else(|| Error::Credentials("module not initialized".to_string()))?
-            .clone();
+    /// Build from a JS strategy object plus the [`Channel`] for the isolate
+    /// that produced it. The channel must come from the calling JS context
+    /// (the `#[neon::export]` macro injects one for any async fn whose first
+    /// argument is `Channel`) — sharing a process-wide channel would route
+    /// callbacks to the wrong isolate when the addon is loaded from multiple
+    /// Node Worker threads, panicking inside `Root::to_inner`.
+    async fn from_root(strategy: Root<JsObject>, channel: Channel) -> Result<Self, Error> {
         let strategy = Arc::new(strategy);
         let strategy_for_lookup = Arc::clone(&strategy);
         let get_token = channel
@@ -856,13 +855,20 @@ fn to_query_plaintext(
 #[cfg(not(target_arch = "wasm32"))]
 #[neon::export]
 pub async fn new_client(
+    // First-arg `Channel` is captured per-call by the `#[neon::export]` macro
+    // from the calling isolate's `Cx`. Threading it into `NeonJsAuthStrategy`
+    // is what keeps JS callbacks pinned to the isolate that owns the
+    // strategy `Root` — see the rationale on `from_root`.
+    channel: Channel,
     Json(opts): Json<NewClientOptions>,
     strategy: Option<Root<JsObject>>,
 ) -> Result<Boxed<Client>, neon::types::extract::Error> {
     let client_opts = opts.client_opts.unwrap_or_default();
 
     let auth = match strategy {
-        Some(s) => NodeAuthStrategy::JsBacked(NeonJsAuthStrategy::from_root(s).await?),
+        Some(s) => {
+            NodeAuthStrategy::JsBacked(NeonJsAuthStrategy::from_root(s, channel).await?)
+        }
         None => NodeAuthStrategy::Auto(Box::new(client_opts.creds.build_strategy()?)),
     };
     let zerokms = ZeroKMSBuilder::new(auth)
@@ -1399,12 +1405,6 @@ fn into_store_ciphertext(output: EqlOutput) -> Result<EqlCiphertext, Error> {
 #[cfg(not(target_arch = "wasm32"))]
 static RUNTIME: OnceCell<Runtime> = OnceCell::new();
 
-/// Channel captured at module init so [`NeonJsAuthStrategy`] can invoke
-/// JS callables from tokio tasks without threading a `Cx` through every
-/// call site.
-#[cfg(not(target_arch = "wasm32"))]
-static JS_CHANNEL: OnceCell<Channel> = OnceCell::new();
-
 #[cfg(not(target_arch = "wasm32"))]
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
@@ -1413,7 +1413,6 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         .or_else(|err| cx.throw_error(err.to_string()))?;
 
     let _ = neon::set_global_executor(&mut cx, runtime);
-    let _ = JS_CHANNEL.set(cx.channel());
 
     neon::registered().export(&mut cx)?;
 

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -298,19 +298,30 @@ impl NeonJsAuthStrategy {
     /// argument is `Channel`) — sharing a process-wide channel would route
     /// callbacks to the wrong isolate when the addon is loaded from multiple
     /// Node Worker threads, panicking inside `Root::to_inner`.
+    ///
+    /// The stored channel is unref'd so a `Client` holding a JS-backed
+    /// strategy doesn't pin libuv's event loop. The per-call promise
+    /// settlement channel that `#[neon::export]` async wraps each encrypt
+    /// / decrypt with is still referenced for the duration of that call,
+    /// so awaited operations complete normally; only the persistent auth
+    /// channel stops blocking process exit when idle.
     async fn from_root(strategy: Root<JsObject>, channel: Channel) -> Result<Self, Error> {
         let strategy = Arc::new(strategy);
         let strategy_for_lookup = Arc::clone(&strategy);
-        let get_token = channel
+        // Use a clone for the lookup `send` so we can move the original
+        // into the JS-thread closure, unref it there (which requires a
+        // `Cx`), and return it back to be stored on `self`.
+        let sender = channel.clone();
+        let (get_token, channel) = sender
             .send(move |mut cx| {
+                let mut channel = channel;
                 let obj = strategy_for_lookup.to_inner(&mut cx);
                 let func: Handle<JsFunction> = obj.prop(&mut cx, "getToken").get()?;
-                Ok(func.root(&mut cx))
+                channel.unref(&mut cx);
+                Ok((func.root(&mut cx), channel))
             })
             .await
-            .map_err(|e| {
-                Error::Credentials(format!("strategy.getToken lookup failed: {e}"))
-            })?;
+            .map_err(|e| Error::Credentials(format!("strategy.getToken lookup failed: {e}")))?;
         Ok(Self {
             strategy,
             get_token: Arc::new(get_token),

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -352,6 +352,20 @@ impl NeonJsAuthStrategy {
     }
 }
 
+/// Best-effort conversion of a thrown JS value into a Rust string. Wrapped
+/// in `try_catch` because `to_string` itself can throw (e.g. a Proxy with
+/// a throwing trap, an object whose `toString` throws). Any failure falls
+/// back to a generic message — and crucially clears the pending N-API
+/// exception so the channel callback returns cleanly.
+#[cfg(not(target_arch = "wasm32"))]
+fn thrown_to_string<'cx, 'h, C: Context<'cx>>(
+    thrown: Handle<'h, JsValue>,
+    cx: &mut C,
+) -> String {
+    cx.try_catch(|cx| Ok(thrown.to_string(cx)?.value(cx)))
+        .unwrap_or_else(|_| "<non-stringifiable error>".to_string())
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl AuthStrategy for &NeonJsAuthStrategy {
     async fn get_token(self) -> Result<stack_auth::ServiceToken, AuthError> {
@@ -359,53 +373,109 @@ impl AuthStrategy for &NeonJsAuthStrategy {
         let get_token = Arc::clone(&self.get_token);
         let channel = self.channel.clone();
 
-        // Schedule the JS call on the JS thread. The closure returns a
-        // `JsFuture<Result<String, String>>`: outer Result distinguishes
-        // a resolved token (Ok) from a structurally-bad result or a
-        // rejection (Err); inner type carries the token string.
-        let js_future: JsFuture<Result<String, String>> = channel
+        // The channel-callback body is wrapped in `cx.try_catch` so that
+        // *any* synchronous throw (a `getToken` that throws, a `.then`
+        // getter that throws, a downcast that needs to consult a Proxy
+        // trap, etc.) is caught and converted to a plain `Err(String)`.
+        // Without `try_catch`, a `Throw` propagated out of the closure
+        // leaves a pending N-API exception on the env that surfaces as an
+        // unhandled JS rejection even when the Rust caller maps the
+        // resulting `JoinError` into a clean error.
+        //
+        // The inner `Result<JsFuture<...>, String>` is the structural
+        // outcome (a future to await vs. a synthesised error message);
+        // the outer `try_catch` only fires on a real throw.
+        let outer: Result<JsFuture<Result<String, String>>, String> = channel
             .send(move |mut cx| {
-                let strategy_h = strategy.to_inner(&mut cx);
-                let func_h = get_token.to_inner(&mut cx);
-                let args: [Handle<JsValue>; 0] = [];
-                let result = func_h.call(&mut cx, strategy_h, args)?;
-                let promise: Handle<JsPromise> = result.downcast_or_throw(&mut cx)?;
-                promise.to_future(&mut cx, |mut cx, settled| match settled {
-                    Ok(v) => {
-                        let obj = match v.downcast::<JsObject, _>(&mut cx) {
-                            Ok(o) => o,
+                let outcome: Result<JsFuture<Result<String, String>>, String> = match cx
+                    .try_catch(|cx| -> NeonResult<
+                        Result<JsFuture<Result<String, String>>, String>,
+                    > {
+                        let strategy_h = strategy.to_inner(cx);
+                        let func_h = get_token.to_inner(cx);
+                        let args: [Handle<JsValue>; 0] = [];
+                        let result = func_h.call(cx, strategy_h, args)?;
+                        let promise = match result.downcast::<JsPromise, _>(cx) {
+                            Ok(p) => p,
                             Err(_) => {
                                 return Ok(Err(
-                                    "strategy.getToken did not return an object".to_string(),
+                                    "strategy.getToken did not return a Promise"
+                                        .to_string(),
                                 ))
                             }
                         };
-                        let token: Handle<JsString> = match obj.prop(&mut cx, "token").get() {
-                            Ok(t) => t,
-                            Err(_) => return Ok(Err("missing 'token' field".to_string())),
-                        };
-                        Ok(Ok(token.value(&mut cx)))
-                    }
-                    Err(err) => {
-                        let msg = err
-                            .to_string(&mut cx)
-                            .map(|s| s.value(&mut cx))
-                            .unwrap_or_else(|_| "strategy.getToken rejected".to_string());
-                        Ok(Err(msg))
-                    }
-                })
+                        // Inner `to_future` closure: structural mismatches
+                        // (wrong type for resolved value, missing/non-string
+                        // `token`) are returned as `Ok(Err(...))`. The
+                        // remaining Throw risk is a property getter on the
+                        // resolved object that throws — vanishingly rare in
+                        // practice, and the existing try_catch on the outer
+                        // closure body covers throws from this same channel
+                        // dispatch path.
+                        let fut = promise.to_future(cx, |mut cx, settled| {
+                            match settled {
+                                Ok(v) => {
+                                    let obj = match v.downcast::<JsObject, _>(&mut cx) {
+                                        Ok(o) => o,
+                                        Err(_) => {
+                                            return Ok(Err(
+                                                "strategy.getToken did not return an object"
+                                                    .to_string(),
+                                            ))
+                                        }
+                                    };
+                                    let raw: Handle<JsValue> =
+                                        match obj.prop(&mut cx, "token").get() {
+                                            Ok(v) => v,
+                                            Err(_) => {
+                                                return Ok(Err(
+                                                    "could not read 'token' field"
+                                                        .to_string(),
+                                                ))
+                                            }
+                                        };
+                                    if raw.is_a::<JsUndefined, _>(&mut cx)
+                                        || raw.is_a::<JsNull, _>(&mut cx)
+                                    {
+                                        return Ok(Err("missing 'token' field".to_string()));
+                                    }
+                                    let token = match raw.downcast::<JsString, _>(&mut cx) {
+                                        Ok(s) => s,
+                                        Err(_) => {
+                                            return Ok(Err(
+                                                "'token' field is not a string"
+                                                    .to_string(),
+                                            ))
+                                        }
+                                    };
+                                    Ok(Ok(token.value(&mut cx)))
+                                }
+                                Err(err) => Ok(Err(format!(
+                                    "strategy.getToken rejected: {}",
+                                    thrown_to_string(err, &mut cx),
+                                ))),
+                            }
+                        })?;
+                        Ok(Ok(fut))
+                    }) {
+                    Ok(inner) => inner,
+                    Err(thrown) => Err(format!(
+                        "strategy.getToken threw synchronously: {}",
+                        thrown_to_string(thrown, &mut cx),
+                    )),
+                };
+                Ok(outcome)
             })
             .await
             .map_err(|e| AuthError::Server(format!("strategy callback failed: {e}")))?;
 
+        let js_future = outer.map_err(AuthError::Server)?;
         let token_result = js_future
             .await
             .map_err(|e| AuthError::Server(format!("strategy promise await failed: {e}")))?;
-
-        match token_result {
-            Ok(s) => Ok(stack_auth::ServiceToken::new(SecretToken::new(s))),
-            Err(msg) => Err(AuthError::Server(msg)),
-        }
+        token_result
+            .map(|s| stack_auth::ServiceToken::new(SecretToken::new(s)))
+            .map_err(AuthError::Server)
     }
 }
 

--- a/crates/protect-ffi/src/lib.rs
+++ b/crates/protect-ffi/src/lib.rs
@@ -32,8 +32,6 @@ use neon::{
 };
 #[cfg(not(target_arch = "wasm32"))]
 use stack_auth::{AuthStrategy, SecretToken};
-#[cfg(not(target_arch = "wasm32"))]
-use std::future::Future;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -325,59 +323,57 @@ impl NeonJsAuthStrategy {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl AuthStrategy for &NeonJsAuthStrategy {
-    fn get_token(self) -> impl Future<Output = Result<stack_auth::ServiceToken, AuthError>> + Send {
+    async fn get_token(self) -> Result<stack_auth::ServiceToken, AuthError> {
         let strategy = Arc::clone(&self.strategy);
         let get_token = Arc::clone(&self.get_token);
         let channel = self.channel.clone();
-        async move {
-            // Schedule the JS call on the JS thread. The closure returns a
-            // `JsFuture<Result<String, String>>`: outer Result distinguishes
-            // a resolved token (Ok) from a structurally-bad result or a
-            // rejection (Err); inner type carries the token string.
-            let js_future: JsFuture<Result<String, String>> = channel
-                .send(move |mut cx| {
-                    let strategy_h = strategy.to_inner(&mut cx);
-                    let func_h = get_token.to_inner(&mut cx);
-                    let args: [Handle<JsValue>; 0] = [];
-                    let result = func_h.call(&mut cx, strategy_h, args)?;
-                    let promise: Handle<JsPromise> = result.downcast_or_throw(&mut cx)?;
-                    promise.to_future(&mut cx, |mut cx, settled| match settled {
-                        Ok(v) => {
-                            let obj = match v.downcast::<JsObject, _>(&mut cx) {
-                                Ok(o) => o,
-                                Err(_) => {
-                                    return Ok(Err(
-                                        "strategy.getToken did not return an object".to_string(),
-                                    ))
-                                }
-                            };
-                            let token: Handle<JsString> =
-                                match obj.prop(&mut cx, "token").get() {
-                                    Ok(t) => t,
-                                    Err(_) => return Ok(Err("missing 'token' field".to_string())),
-                                };
-                            Ok(Ok(token.value(&mut cx)))
-                        }
-                        Err(err) => {
-                            let msg = err
-                                .to_string(&mut cx)
-                                .map(|s| s.value(&mut cx))
-                                .unwrap_or_else(|_| "strategy.getToken rejected".to_string());
-                            Ok(Err(msg))
-                        }
-                    })
+
+        // Schedule the JS call on the JS thread. The closure returns a
+        // `JsFuture<Result<String, String>>`: outer Result distinguishes
+        // a resolved token (Ok) from a structurally-bad result or a
+        // rejection (Err); inner type carries the token string.
+        let js_future: JsFuture<Result<String, String>> = channel
+            .send(move |mut cx| {
+                let strategy_h = strategy.to_inner(&mut cx);
+                let func_h = get_token.to_inner(&mut cx);
+                let args: [Handle<JsValue>; 0] = [];
+                let result = func_h.call(&mut cx, strategy_h, args)?;
+                let promise: Handle<JsPromise> = result.downcast_or_throw(&mut cx)?;
+                promise.to_future(&mut cx, |mut cx, settled| match settled {
+                    Ok(v) => {
+                        let obj = match v.downcast::<JsObject, _>(&mut cx) {
+                            Ok(o) => o,
+                            Err(_) => {
+                                return Ok(Err(
+                                    "strategy.getToken did not return an object".to_string(),
+                                ))
+                            }
+                        };
+                        let token: Handle<JsString> = match obj.prop(&mut cx, "token").get() {
+                            Ok(t) => t,
+                            Err(_) => return Ok(Err("missing 'token' field".to_string())),
+                        };
+                        Ok(Ok(token.value(&mut cx)))
+                    }
+                    Err(err) => {
+                        let msg = err
+                            .to_string(&mut cx)
+                            .map(|s| s.value(&mut cx))
+                            .unwrap_or_else(|_| "strategy.getToken rejected".to_string());
+                        Ok(Err(msg))
+                    }
                 })
-                .await
-                .map_err(|e| AuthError::Server(format!("strategy callback failed: {e}")))?;
+            })
+            .await
+            .map_err(|e| AuthError::Server(format!("strategy callback failed: {e}")))?;
 
-            let token_result = js_future
-                .await
-                .map_err(|e| AuthError::Server(format!("strategy promise await failed: {e}")))?;
+        let token_result = js_future
+            .await
+            .map_err(|e| AuthError::Server(format!("strategy promise await failed: {e}")))?;
 
-            match token_result {
-                Ok(s) => Ok(stack_auth::ServiceToken::new(SecretToken::new(s))),
-                Err(msg) => Err(AuthError::Server(msg)),
-            }
+        match token_result {
+            Ok(s) => Ok(stack_auth::ServiceToken::new(SecretToken::new(s))),
+            Err(msg) => Err(AuthError::Server(msg)),
         }
     }
 }
@@ -386,20 +382,22 @@ impl AuthStrategy for &NeonJsAuthStrategy {
 /// filesystem/env-backed [`AutoStrategy`] (built from credentials in opts
 /// or the profile store) or a [`NeonJsAuthStrategy`] supplied by the
 /// caller via `opts.strategy`.
+///
+/// `AutoStrategy` is boxed because it's substantially larger than the
+/// JS-backed variant — without indirection clippy flags the size
+/// imbalance as `large_enum_variant`.
 #[cfg(not(target_arch = "wasm32"))]
 enum NodeAuthStrategy {
-    Auto(AutoStrategy),
+    Auto(Box<AutoStrategy>),
     JsBacked(NeonJsAuthStrategy),
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl AuthStrategy for &NodeAuthStrategy {
-    fn get_token(self) -> impl Future<Output = Result<stack_auth::ServiceToken, AuthError>> + Send {
-        async move {
-            match self {
-                NodeAuthStrategy::Auto(s) => s.get_token().await,
-                NodeAuthStrategy::JsBacked(s) => s.get_token().await,
-            }
+    async fn get_token(self) -> Result<stack_auth::ServiceToken, AuthError> {
+        match self {
+            NodeAuthStrategy::Auto(s) => (&**s).get_token().await,
+            NodeAuthStrategy::JsBacked(s) => s.get_token().await,
         }
     }
 }
@@ -872,7 +870,7 @@ pub async fn new_client(
 
     let auth = match strategy {
         Some(s) => NodeAuthStrategy::JsBacked(NeonJsAuthStrategy::from_root(s).await?),
-        None => NodeAuthStrategy::Auto(client_opts.creds.build_strategy()?),
+        None => NodeAuthStrategy::Auto(Box::new(client_opts.creds.build_strategy()?)),
     };
     let zerokms = ZeroKMSBuilder::new(auth)
         .with_key_provider(client_opts.creds.build_key_provider()?)

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -336,7 +336,6 @@ async fn do_encrypt(client: &WasmClient, opts: EncryptOptions) -> Result<Encrypt
     let eql_opts = EqlEncryptOpts {
         keyset_id: None,
         lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
-        service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
         decryption_policy: None,
@@ -397,7 +396,6 @@ async fn do_encrypt_bulk(
         let eql_opts = EqlEncryptOpts {
             keyset_id: None,
             lock_context: Cow::Owned(lock_context),
-            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
             decryption_policy: None,
@@ -449,7 +447,6 @@ async fn do_encrypt_query(
     let eql_opts = EqlEncryptOpts {
         keyset_id: None,
         lock_context: Cow::Owned(opts.lock_context.map(Into::into).unwrap_or_default()),
-        service_token: opts.service_token.map(Cow::Owned),
         unverified_context: opts.unverified_context.map(Cow::Owned),
         index_types: None,
         decryption_policy: None,
@@ -516,7 +513,6 @@ async fn do_encrypt_query_bulk(
         let eql_opts = EqlEncryptOpts {
             keyset_id: None,
             lock_context: Cow::Owned(lock_context),
-            service_token: opts.service_token.as_ref().map(Cow::Borrowed),
             unverified_context: opts.unverified_context.as_ref().map(Cow::Borrowed),
             index_types: None,
             decryption_policy: None,
@@ -543,12 +539,7 @@ async fn do_decrypt(client: &WasmClient, opts: DecryptOptions) -> Result<JsPlain
 
     let bytes = client
         .zerokms
-        .decrypt_single(
-            encrypted_record,
-            None,
-            opts.service_token.map(Cow::Owned),
-            opts.unverified_context.as_ref(),
-        )
+        .decrypt_single(encrypted_record, None, opts.unverified_context.as_ref())
         .await
         .map_err(Error::from)?;
     let plaintext = Plaintext::from_slice(bytes.as_slice()).map_err(Error::from)?;
@@ -571,12 +562,7 @@ async fn do_decrypt_bulk(
 
     let decrypted = client
         .zerokms
-        .decrypt(
-            encrypted_records,
-            None,
-            opts.service_token.map(Cow::Owned),
-            opts.unverified_context.as_ref(),
-        )
+        .decrypt(encrypted_records, None, opts.unverified_context.as_ref())
         .await?;
 
     decrypted
@@ -623,11 +609,7 @@ async fn do_decrypt_bulk_fallible(
 
     let decrypted = client
         .zerokms
-        .decrypt_fallible(
-            valid_records,
-            opts.service_token.map(Cow::Owned),
-            opts.unverified_context.map(Cow::Owned),
-        )
+        .decrypt_fallible(valid_records, opts.unverified_context.map(Cow::Owned))
         .await?;
 
     for (item, idx) in decrypted.into_iter().zip(valid_indices) {

--- a/crates/protect-ffi/src/wasm.rs
+++ b/crates/protect-ffi/src/wasm.rs
@@ -180,20 +180,27 @@ struct NewClientOpts {
 
 /// Construct a [`WasmClient`].
 ///
-/// `strategy` must be an `@cipherstash/auth`-shaped object — anything with
-/// a `getToken(): Promise<{ token: string, ... }>` method works.
+/// `opts.strategy` must be an `@cipherstash/auth`-shaped object — anything
+/// with a `getToken(): Promise<{ token: string, ... }>` method works. It is
+/// required: wasm has no env / filesystem fallback path.
 #[wasm_bindgen(js_name = newClient)]
-pub async fn new_client(strategy: JsValue, opts: JsValue) -> Result<WasmClient, JsValue> {
-    let mut opts: NewClientOpts =
-        serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
-
-    // Pull `getToken` off the strategy object.
+pub async fn new_client(opts: JsValue) -> Result<WasmClient, JsValue> {
+    // Extract `strategy` before serde — the JS function on it can't survive
+    // serde_wasm_bindgen, and the rest of the opts has no JS-callable fields.
+    let strategy = js_sys::Reflect::get(&opts, &JsValue::from_str("strategy"))
+        .map_err(|e| js_error(&format!("opts.strategy lookup failed: {e:?}")))?;
+    if strategy.is_undefined() || strategy.is_null() {
+        return Err(js_error("opts.strategy is required"));
+    }
     let get_token = js_sys::Reflect::get(&strategy, &JsValue::from_str("getToken"))
-        .map_err(|e| js_error(&format!("strategy.getToken not found: {e:?}")))?;
+        .map_err(|e| js_error(&format!("opts.strategy.getToken not found: {e:?}")))?;
     let get_token: js_sys::Function = get_token
         .dyn_into()
-        .map_err(|_| js_error("strategy.getToken is not a function"))?;
+        .map_err(|_| js_error("opts.strategy.getToken is not a function"))?;
     let auth = JsAuthStrategy::new(strategy.clone(), get_token);
+
+    let mut opts: NewClientOpts =
+        serde_wasm_bindgen::from_value(opts).map_err(|e| js_error(&e.to_string()))?;
 
     // Decode the hex buffer in place rather than via `SecretKey::from_hex`:
     // `from_hex` takes a `String` for the UUID, which would force an

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cipherstash/auth": "0.37.0-alpha.8",
+        "@cipherstash/auth": "^0.38.0",
         "@cipherstash/protect-ffi": "..",
         "pg": "^8.13.3"
       },
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"
@@ -112,16 +112,16 @@
       }
     },
     "node_modules/@cipherstash/auth": {
-      "version": "0.37.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@cipherstash/auth/-/auth-0.37.0-alpha.8.tgz",
-      "integrity": "sha512-Bwl8LdYEqQUGcfVfhyemOZa6ZrWEvA3av3c9Vg1Y1eR6OkFLgf4QEI4lHGIiNlU34BmZKShpGwrTWUN+Kct6vg==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@cipherstash/auth/-/auth-0.38.0.tgz",
+      "integrity": "sha512-jsrJ8fqenjcuMGWG1pBzVUflZUQZ7c1MosYiqyxh6fYDsMlTl70S8agDSsa2ciXmVQyti49n4on8c1CZxGhF5w==",
       "peerDependencies": {
-        "@cipherstash/auth-darwin-arm64": "0.37.0-alpha.8",
-        "@cipherstash/auth-darwin-x64": "0.37.0-alpha.8",
-        "@cipherstash/auth-linux-arm64-gnu": "0.37.0-alpha.8",
-        "@cipherstash/auth-linux-x64-gnu": "0.37.0-alpha.8",
-        "@cipherstash/auth-linux-x64-musl": "0.37.0-alpha.8",
-        "@cipherstash/auth-win32-x64-msvc": "0.37.0-alpha.8"
+        "@cipherstash/auth-darwin-arm64": "0.38.0",
+        "@cipherstash/auth-darwin-x64": "0.38.0",
+        "@cipherstash/auth-linux-arm64-gnu": "0.38.0",
+        "@cipherstash/auth-linux-x64-gnu": "0.38.0",
+        "@cipherstash/auth-linux-x64-musl": "0.38.0",
+        "@cipherstash/auth-win32-x64-msvc": "0.38.0"
       },
       "peerDependenciesMeta": {
         "@cipherstash/auth-darwin-arm64": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@cipherstash/auth": "0.37.0-alpha.8",
+    "@cipherstash/auth": "^0.38.0",
     "@cipherstash/protect-ffi": "..",
     "pg": "^8.13.3"
   },

--- a/integration-tests/tasks.toml
+++ b/integration-tests/tasks.toml
@@ -37,8 +37,12 @@ run = [
 description = "Run the integration tests"
 dir = "{{ config_root }}/integration-tests"
 depends = ["start-db"]
+# The wasm-round-trip suite reads `dist/wasm/protect_ffi_inline.js`, so
+# the wasm artifacts must exist before vitest runs even though the rest
+# of the integration tests only need the Neon binding.
 run = [
     "mise run build:debug",
+    "npm run --prefix .. build:wasm",
     "npx vitest --exclude tests/lock-context.test.ts",
 ]
 
@@ -46,4 +50,8 @@ run = [
 description = "Run all integration tests (includes lock context tests)"
 dir = "{{ config_root }}/integration-tests"
 depends = ["start-db"]
-run = ["mise run build:debug", "npx vitest"]
+run = [
+    "mise run build:debug",
+    "npm run --prefix .. build:wasm",
+    "npx vitest",
+]

--- a/integration-tests/tests/event-loop-exit.test.ts
+++ b/integration-tests/tests/event-loop-exit.test.ts
@@ -31,12 +31,6 @@ const COMMON_ENV = [
 ]
 const missingCommonEnv = COMMON_ENV.filter((k) => !process.env[k])
 
-// The JsBacked fixture builds an AccessKeyStrategy via @cipherstash/auth's
-// wasm-inline build, which needs an explicit region string.
-const missingJsBackedEnv = missingCommonEnv.concat(
-  process.env.CS_REGION ? [] : ['CS_REGION'],
-)
-
 // Generous: we expect the child to exit within ~1s of completing the
 // round trip; 15s gives the auth + ZeroKMS round trip plenty of slack
 // on slow CI without masking a real hang.
@@ -79,8 +73,8 @@ function runChild(scriptPath: string): Promise<ChildOutcome> {
   })
 }
 
-describe('event loop exit', () => {
-  test.skipIf(missingJsBackedEnv.length > 0)('exits naturally after a JsBacked-strategy round trip', async () => {
+describe.skipIf(missingCommonEnv.length > 0)('event loop exit', () => {
+  test('exits naturally after a JsBacked-strategy round trip', async () => {
     const script = resolve(
       __dirname,
       'fixtures/event-loop-exit-jsbacked.cjs',
@@ -97,7 +91,7 @@ describe('event loop exit', () => {
     expect(outcome.stdout.trim()).toBe('ok')
   }, EXIT_TIMEOUT_MS + 5_000)
 
-  test.skipIf(missingCommonEnv.length > 0)('exits naturally with the AutoStrategy fallback', async () => {
+  test('exits naturally with the AutoStrategy fallback', async () => {
     const script = resolve(__dirname, 'fixtures/event-loop-exit-auto.cjs')
     const outcome = await runChild(script)
     expect(

--- a/integration-tests/tests/event-loop-exit.test.ts
+++ b/integration-tests/tests/event-loop-exit.test.ts
@@ -1,0 +1,113 @@
+// Verifies that a Node script using protect-ffi exits naturally after
+// its work is done — i.e. nothing in this addon pins libuv past the
+// completion of awaited operations.
+//
+// Before this fix:
+//   * #[neon::main] installed a process-wide referenced Channel into
+//     a static OnceCell, pinning the event loop forever.
+//   * `NeonJsAuthStrategy` then held its own referenced Channel for the
+//     life of the Client.
+//
+// After this fix:
+//   * The static is gone; the strategy captures a per-call Channel.
+//   * That Channel is unref'd inside `from_root` (after the getToken
+//     lookup) so the Client doesn't block process exit while idle.
+//
+// We assert that two scripts — one using `opts.strategy` (JsBacked) and
+// one using the env-backed AutoStrategy fallback — terminate on their
+// own within a short timeout. If a Channel were still pinning libuv
+// the child would hang and the test would fail via timeout.
+
+import 'dotenv/config'
+import { type ChildProcess, spawn } from 'node:child_process'
+import { resolve } from 'node:path'
+import { describe, expect, test } from 'vitest'
+
+const COMMON_ENV = [
+  'CS_WORKSPACE_CRN',
+  'CS_CLIENT_ACCESS_KEY',
+  'CS_CLIENT_ID',
+  'CS_CLIENT_KEY',
+]
+const missingCommonEnv = COMMON_ENV.filter((k) => !process.env[k])
+
+// The JsBacked fixture builds an AccessKeyStrategy via @cipherstash/auth's
+// wasm-inline build, which needs an explicit region string.
+const missingJsBackedEnv = missingCommonEnv.concat(
+  process.env.CS_REGION ? [] : ['CS_REGION'],
+)
+
+// Generous: we expect the child to exit within ~1s of completing the
+// round trip; 15s gives the auth + ZeroKMS round trip plenty of slack
+// on slow CI without masking a real hang.
+const EXIT_TIMEOUT_MS = 15_000
+
+type ChildOutcome = {
+  code: number | null
+  signal: NodeJS.Signals | null
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+function runChild(scriptPath: string): Promise<ChildOutcome> {
+  return new Promise((resolveOutcome) => {
+    const child: ChildProcess = spawn(process.execPath, [scriptPath], {
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+
+    let stdout = ''
+    let stderr = ''
+    child.stdout?.on('data', (chunk) => {
+      stdout += chunk.toString()
+    })
+    child.stderr?.on('data', (chunk) => {
+      stderr += chunk.toString()
+    })
+
+    let timedOut = false
+    const timer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, EXIT_TIMEOUT_MS)
+
+    child.on('exit', (code, signal) => {
+      clearTimeout(timer)
+      resolveOutcome({ code, signal, stdout, stderr, timedOut })
+    })
+  })
+}
+
+describe('event loop exit', () => {
+  test.skipIf(missingJsBackedEnv.length > 0)('exits naturally after a JsBacked-strategy round trip', async () => {
+    const script = resolve(
+      __dirname,
+      'fixtures/event-loop-exit-jsbacked.cjs',
+    )
+    const outcome = await runChild(script)
+    expect(
+      outcome.timedOut,
+      `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+    ).toBe(false)
+    expect(
+      outcome.code,
+      `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+    ).toBe(0)
+    expect(outcome.stdout.trim()).toBe('ok')
+  }, EXIT_TIMEOUT_MS + 5_000)
+
+  test.skipIf(missingCommonEnv.length > 0)('exits naturally with the AutoStrategy fallback', async () => {
+    const script = resolve(__dirname, 'fixtures/event-loop-exit-auto.cjs')
+    const outcome = await runChild(script)
+    expect(
+      outcome.timedOut,
+      `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+    ).toBe(false)
+    expect(
+      outcome.code,
+      `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+    ).toBe(0)
+    expect(outcome.stdout.trim()).toBe('ok')
+  }, EXIT_TIMEOUT_MS + 5_000)
+})

--- a/integration-tests/tests/event-loop-exit.test.ts
+++ b/integration-tests/tests/event-loop-exit.test.ts
@@ -74,34 +74,39 @@ function runChild(scriptPath: string): Promise<ChildOutcome> {
 }
 
 describe.skipIf(missingCommonEnv.length > 0)('event loop exit', () => {
-  test('exits naturally after a JsBacked-strategy round trip', async () => {
-    const script = resolve(
-      __dirname,
-      'fixtures/event-loop-exit-jsbacked.cjs',
-    )
-    const outcome = await runChild(script)
-    expect(
-      outcome.timedOut,
-      `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
-    ).toBe(false)
-    expect(
-      outcome.code,
-      `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
-    ).toBe(0)
-    expect(outcome.stdout.trim()).toBe('ok')
-  }, EXIT_TIMEOUT_MS + 5_000)
+  test(
+    'exits naturally after a JsBacked-strategy round trip',
+    async () => {
+      const script = resolve(__dirname, 'fixtures/event-loop-exit-jsbacked.cjs')
+      const outcome = await runChild(script)
+      expect(
+        outcome.timedOut,
+        `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+      ).toBe(false)
+      expect(
+        outcome.code,
+        `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+      ).toBe(0)
+      expect(outcome.stdout.trim()).toBe('ok')
+    },
+    EXIT_TIMEOUT_MS + 5_000,
+  )
 
-  test('exits naturally with the AutoStrategy fallback', async () => {
-    const script = resolve(__dirname, 'fixtures/event-loop-exit-auto.cjs')
-    const outcome = await runChild(script)
-    expect(
-      outcome.timedOut,
-      `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
-    ).toBe(false)
-    expect(
-      outcome.code,
-      `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
-    ).toBe(0)
-    expect(outcome.stdout.trim()).toBe('ok')
-  }, EXIT_TIMEOUT_MS + 5_000)
+  test(
+    'exits naturally with the AutoStrategy fallback',
+    async () => {
+      const script = resolve(__dirname, 'fixtures/event-loop-exit-auto.cjs')
+      const outcome = await runChild(script)
+      expect(
+        outcome.timedOut,
+        `child hung; libuv still pinned\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+      ).toBe(false)
+      expect(
+        outcome.code,
+        `child failed\nstdout: ${outcome.stdout}\nstderr: ${outcome.stderr}`,
+      ).toBe(0)
+      expect(outcome.stdout.trim()).toBe('ok')
+    },
+    EXIT_TIMEOUT_MS + 5_000,
+  )
 })

--- a/integration-tests/tests/fixtures/event-loop-exit-auto.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-auto.cjs
@@ -21,7 +21,6 @@ const encryptConfig = {
     },
   },
 }
-
 ;(async () => {
   const client = await newClient({ encryptConfig })
 

--- a/integration-tests/tests/fixtures/event-loop-exit-auto.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-auto.cjs
@@ -1,0 +1,45 @@
+// Fixture for the "event loop exits naturally" integration test —
+// AutoStrategy variant.
+//
+// Same shape as event-loop-exit-jsbacked.cjs but with NO `opts.strategy`,
+// so the Rust side builds an AutoStrategy from env credentials. There is
+// no JS-backed auth Channel on this path, so this script proves the
+// previous process-wide `JS_CHANNEL` static (now removed) is no longer
+// pinning libuv either.
+
+require('dotenv/config')
+const { newClient, encrypt, decrypt } = require('@cipherstash/protect-ffi')
+
+const encryptConfig = {
+  v: 1,
+  tables: {
+    users: {
+      email: {
+        cast_as: 'string',
+        indexes: { unique: {} },
+      },
+    },
+  },
+}
+
+;(async () => {
+  const client = await newClient({ encryptConfig })
+
+  const ciphertext = await encrypt(client, {
+    plaintext: 'event-loop-exit-test@example.com',
+    table: 'users',
+    column: 'email',
+  })
+
+  const plaintext = await decrypt(client, { ciphertext })
+  if (plaintext !== 'event-loop-exit-test@example.com') {
+    console.error(`round-trip mismatch: got ${plaintext}`)
+    process.exitCode = 2
+    return
+  }
+
+  console.log('ok')
+})().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
@@ -1,0 +1,59 @@
+// Fixture for the "event loop exits naturally" integration test.
+//
+// Creates a Client using a JS-supplied `opts.strategy`, performs one
+// encrypt + decrypt, then returns. Does NOT call process.exit(). If the
+// Node event loop drains correctly, this script terminates on its own;
+// if anything (e.g. an unref'd auth Channel) is still pinning libuv,
+// the parent test times out and kills it.
+
+require('dotenv/config')
+const { newClient, encrypt, decrypt } = require('@cipherstash/protect-ffi')
+
+const encryptConfig = {
+  v: 1,
+  tables: {
+    users: {
+      email: {
+        cast_as: 'string',
+        indexes: { unique: {} },
+      },
+    },
+  },
+}
+
+;(async () => {
+  // Use the wasm-inline build of @cipherstash/auth — it has no native
+  // binary dep, works on any Node target, and lets us exercise the
+  // `opts.strategy` (JsBacked) code path with a real getToken.
+  const { AccessKeyStrategy } = await import('@cipherstash/auth/wasm-inline')
+  const accessKey = process.env.CS_CLIENT_ACCESS_KEY
+  const region = process.env.CS_REGION
+  if (!accessKey || !region) {
+    throw new Error(
+      'event-loop-exit-jsbacked fixture needs CS_CLIENT_ACCESS_KEY and CS_REGION',
+    )
+  }
+  const strategy = AccessKeyStrategy.create(region, accessKey)
+
+  const client = await newClient({ encryptConfig, strategy })
+
+  const ciphertext = await encrypt(client, {
+    plaintext: 'event-loop-exit-test@example.com',
+    table: 'users',
+    column: 'email',
+  })
+
+  const plaintext = await decrypt(client, { ciphertext })
+  if (plaintext !== 'event-loop-exit-test@example.com') {
+    console.error(`round-trip mismatch: got ${plaintext}`)
+    process.exitCode = 2
+    return
+  }
+
+  // No explicit process.exit(). The presence of an unref'd auth Channel
+  // (the fix under test) is what lets Node terminate cleanly here.
+  console.log('ok')
+})().catch((err) => {
+  console.error(err)
+  process.exitCode = 1
+})

--- a/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
@@ -25,14 +25,24 @@ const encryptConfig = {
   // Use the wasm-inline build of @cipherstash/auth — it has no native
   // binary dep, works on any Node target, and lets us exercise the
   // `opts.strategy` (JsBacked) code path with a real getToken.
+  // Note: stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN;
+  // the wasm AccessKeyStrategy.create still takes a region string as its
+  // first argument (named that way in the .d.ts) but expects the
+  // <region>.<provider> form, which is the middle segment of a CRN like
+  // `crn:ap-southeast-2.aws:<workspace>`.
   const { AccessKeyStrategy } = await import('@cipherstash/auth/wasm-inline')
   const accessKey = process.env.CS_CLIENT_ACCESS_KEY
-  const region = process.env.CS_REGION
-  if (!accessKey || !region) {
+  const workspaceCrn = process.env.CS_WORKSPACE_CRN
+  if (!accessKey || !workspaceCrn) {
     throw new Error(
-      'event-loop-exit-jsbacked fixture needs CS_CLIENT_ACCESS_KEY and CS_REGION',
+      'event-loop-exit-jsbacked fixture needs CS_CLIENT_ACCESS_KEY and CS_WORKSPACE_CRN',
     )
   }
+  const match = workspaceCrn.match(/^crn:([^:]+):/)
+  if (!match) {
+    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${workspaceCrn}`)
+  }
+  const region = match[1]
   const strategy = AccessKeyStrategy.create(region, accessKey)
 
   const client = await newClient({ encryptConfig, strategy })

--- a/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
@@ -20,7 +20,6 @@ const encryptConfig = {
     },
   },
 }
-
 ;(async () => {
   // Use the wasm-inline build of @cipherstash/auth — it has no native
   // binary dep, works on any Node target, and lets us exercise the

--- a/integration-tests/tests/js-strategy.test.ts
+++ b/integration-tests/tests/js-strategy.test.ts
@@ -100,6 +100,62 @@ describe.skipIf(missingEnv.length > 0)('opts.strategy (JsBacked)', () => {
 
     await expect(
       newClient({ encryptConfig, clientOpts, strategy }),
-    ).rejects.toThrow()
+    ).rejects.toThrow(/getToken/)
+  })
+
+  test('rejects when getToken throws synchronously', async () => {
+    const strategy: AuthStrategy = {
+      getToken: (() => {
+        throw new Error('sync throw from getToken')
+      }) as AuthStrategy['getToken'],
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/threw synchronously|sync throw from getToken/)
+  })
+
+  test('rejects when getToken returns a non-Promise', async () => {
+    const strategy: AuthStrategy = {
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately mistyped
+      getToken: (() => ({ token: 'not-wrapped-in-a-promise' })) as any,
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/did not return a Promise/)
+  })
+
+  test('rejects when getToken resolves with a non-object', async () => {
+    const strategy: AuthStrategy = {
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately mistyped
+      getToken: (async () => 'just-a-string') as any,
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/did not return an object/)
+  })
+
+  test('rejects when getToken resolves without a token field', async () => {
+    const strategy: AuthStrategy = {
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately mistyped
+      getToken: (async () => ({ notToken: 'oops' })) as any,
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/missing 'token' field/)
+  })
+
+  test("rejects when the 'token' field is not a string", async () => {
+    const strategy: AuthStrategy = {
+      // biome-ignore lint/suspicious/noExplicitAny: deliberately mistyped
+      getToken: (async () => ({ token: 12345 })) as any,
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/'token' field is not a string/)
   })
 })

--- a/integration-tests/tests/js-strategy.test.ts
+++ b/integration-tests/tests/js-strategy.test.ts
@@ -103,6 +103,16 @@ describe.skipIf(missingEnv.length > 0)('opts.strategy (JsBacked)', () => {
     ).rejects.toThrow(/getToken/)
   })
 
+  test('rejects a strategy whose getToken is not callable', async () => {
+    // present but not a function -> exercises the downcast-failure arm,
+    // distinct from the missing/undefined arm covered above.
+    const strategy = { getToken: 'not-a-function' } as unknown as AuthStrategy
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/getToken is not a function/)
+  })
+
   test('rejects when getToken throws synchronously', async () => {
     const strategy: AuthStrategy = {
       getToken: (() => {

--- a/integration-tests/tests/js-strategy.test.ts
+++ b/integration-tests/tests/js-strategy.test.ts
@@ -1,0 +1,105 @@
+// Behavioural tests for the Node-side `opts.strategy` (JsBacked) path.
+//
+// The event-loop-exit suite proves the JsBacked path works end-to-end and
+// drains cleanly. This suite asserts the strategy contract directly:
+//
+//   1. `getToken` is invoked from Rust for every ZeroKMS-bound operation
+//      (no Rust-side AutoRefresh caching, matching the wasm contract).
+//   2. A rejected `getToken` Promise propagates back as a client error
+//      instead of being silently swallowed.
+//   3. A strategy without a callable `getToken` is rejected at
+//      construction with a clear error.
+
+import 'dotenv/config'
+import { AccessKeyStrategy } from '@cipherstash/auth/wasm-inline'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type AuthStrategy,
+  type ClientOpts,
+  decrypt,
+  encrypt,
+  newClient,
+} from '@cipherstash/protect-ffi'
+
+import { encryptConfig } from './common.js'
+
+const REQUIRED_ENV = [
+  'CS_WORKSPACE_CRN',
+  'CS_CLIENT_ACCESS_KEY',
+  'CS_CLIENT_ID',
+  'CS_CLIENT_KEY',
+] as const
+const missingEnv = REQUIRED_ENV.filter((k) => !process.env[k])
+
+function buildAccessKeyStrategy(): AccessKeyStrategy {
+  const crn = process.env.CS_WORKSPACE_CRN
+  const accessKey = process.env.CS_CLIENT_ACCESS_KEY
+  if (!crn || !accessKey) {
+    throw new Error('unreachable: skipIf gates this')
+  }
+  // stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN; the
+  // wasm AccessKeyStrategy.create still takes a region string but expects
+  // the `<region>.<provider>` middle segment of the CRN.
+  const match = crn.match(/^crn:([^:]+):/)
+  if (!match) {
+    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${crn}`)
+  }
+  return AccessKeyStrategy.create(match[1], accessKey)
+}
+
+const clientOpts: ClientOpts = {
+  clientId: process.env.CS_CLIENT_ID,
+  clientKey: process.env.CS_CLIENT_KEY,
+}
+
+describe.skipIf(missingEnv.length > 0)('opts.strategy (JsBacked)', () => {
+  test('invokes getToken from Rust for every operation', async () => {
+    const inner = buildAccessKeyStrategy()
+    let callCount = 0
+    const strategy: AuthStrategy = {
+      async getToken() {
+        callCount++
+        return await inner.getToken()
+      },
+    }
+
+    const client = await newClient({ encryptConfig, clientOpts, strategy })
+    expect(callCount).toBeGreaterThanOrEqual(1) // newClient → load_keyset
+
+    const beforeEncrypt = callCount
+    const ciphertext = await encrypt(client, {
+      plaintext: 'alice@example.com',
+      table: 'users',
+      column: 'email',
+    })
+    expect(callCount).toBeGreaterThan(beforeEncrypt)
+
+    const beforeDecrypt = callCount
+    const decrypted = await decrypt(client, { ciphertext })
+    expect(decrypted).toBe('alice@example.com')
+    expect(callCount).toBeGreaterThan(beforeDecrypt)
+  })
+
+  test('propagates a rejected getToken Promise to the client error', async () => {
+    const strategy: AuthStrategy = {
+      async getToken() {
+        throw new Error('strategy intentionally rejected for test')
+      },
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/strategy intentionally rejected for test/)
+  })
+
+  test('rejects a strategy without a getToken function', async () => {
+    // Cast through `unknown` so TS doesn't reject the malformed shape
+    // before the test can exercise the runtime check.
+    const strategy = { notGetToken: () => {} } as unknown as AuthStrategy
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow()
+  })
+})

--- a/integration-tests/tests/scalar-bulk.test.ts
+++ b/integration-tests/tests/scalar-bulk.test.ts
@@ -54,7 +54,6 @@ describe('encryptBulk and decryptBulk', async () => {
 
     const ciphertexts = await encryptBulk(client, {
       plaintexts: payloads,
-      serviceToken: undefined,
       unverifiedContext: undefined,
     })
 
@@ -63,7 +62,6 @@ describe('encryptBulk and decryptBulk', async () => {
         ciphertext,
         lockContext: undefined,
       })),
-      serviceToken: undefined,
       unverifiedContext: undefined,
     })
 

--- a/integration-tests/tests/scalar.test.ts
+++ b/integration-tests/tests/scalar.test.ts
@@ -60,7 +60,6 @@ describe.each(cases)('encrypt and decrypt', ({ identifier, plaintext }) => {
 
       const ciphertext = await encrypt(client, {
         plaintext,
-        serviceToken: undefined,
         lockContext: undefined,
         unverifiedContext: undefined,
         ...identifier,
@@ -69,7 +68,6 @@ describe.each(cases)('encrypt and decrypt', ({ identifier, plaintext }) => {
       const decrypted = await decrypt(client, {
         ciphertext,
         lockContext: undefined,
-        serviceToken: undefined,
         unverifiedContext: undefined,
       })
 

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -57,7 +57,12 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
     encrypt: (
       client: unknown,
       opts: Record<string, unknown>,
-    ) => Promise<{ i: { t: string; c: string }; b?: { c: string } }>
+    ) => Promise<{
+      k: 'ct' | 'sv'
+      i: { t: string; c: string }
+      c?: string
+      hm?: string
+    }>
     decrypt: (client: unknown, opts: Record<string, unknown>) => Promise<string>
     isEncrypted: (raw: unknown) => boolean
   }
@@ -136,8 +141,12 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
     })
 
     expect(wasm.isEncrypted(ciphertext)).toBe(true)
+    expect(ciphertext.k).toBe('ct')
     expect(ciphertext.i).toEqual({ t: 'users', c: 'email' })
-    expect(ciphertext.b?.c).toBeTruthy()
+    // unique-index HMAC lives at the top-level `hm` field in EQL v2.3.
+    expect(ciphertext.hm).toBeTruthy()
+    // MessagePack-Base85 ciphertext lives at top-level `c` for scalar payloads.
+    expect(ciphertext.c).toBeTruthy()
 
     const decrypted = await wasm.decrypt(client, { ciphertext })
     expect(decrypted).toBe(plaintext)

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -53,10 +53,7 @@ const WASM_INLINE_PATH = resolve(
 // opaque ESM import error.
 describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
   type WasmModule = {
-    newClient: (
-      strategy: unknown,
-      opts: Record<string, unknown>,
-    ) => Promise<unknown>
+    newClient: (opts: Record<string, unknown>) => Promise<unknown>
     encrypt: (
       client: unknown,
       opts: Record<string, unknown>,
@@ -96,7 +93,8 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
 
     const strategy = AccessKeyStrategy.create(env.region, env.accessKey)
 
-    const client = await wasm.newClient(strategy, {
+    const client = await wasm.newClient({
+      strategy,
       encryptConfig: {
         v: 1,
         tables: {

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -107,9 +107,7 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
     // segment of a CRN like `crn:ap-southeast-2.aws:<workspace>`.
     const crnMatch = env.workspaceCrn.match(/^crn:([^:]+):/)
     if (!crnMatch) {
-      throw new Error(
-        `unexpected CS_WORKSPACE_CRN format: ${env.workspaceCrn}`,
-      )
+      throw new Error(`unexpected CS_WORKSPACE_CRN format: ${env.workspaceCrn}`)
     }
     const strategy = AccessKeyStrategy.create(crnMatch[1], env.accessKey)
 

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -150,3 +150,33 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
     expect(decrypted).toBe(plaintext)
   })
 })
+
+// The wasm `newClient` requires `opts.strategy` (no env/fs fallback). Both
+// guards run *before* serde and before any network call, so they need no
+// credentials — gate only on the wasm build existing, not on the env vars.
+describe.skipIf(!existsSync(WASM_INLINE_PATH))(
+  'wasm newClient validation',
+  () => {
+    type WasmModule = {
+      newClient: (opts: Record<string, unknown>) => Promise<unknown>
+    }
+    const minimalConfig = { v: 1, tables: {} }
+
+    test('rejects when opts.strategy is missing', async () => {
+      const wasm = (await import(WASM_INLINE_PATH)) as WasmModule
+      await expect(
+        wasm.newClient({ encryptConfig: minimalConfig }),
+      ).rejects.toThrow(/opts\.strategy is required/)
+    })
+
+    test('rejects a non-callable getToken', async () => {
+      const wasm = (await import(WASM_INLINE_PATH)) as WasmModule
+      await expect(
+        wasm.newClient({
+          strategy: { getToken: 42 },
+          encryptConfig: minimalConfig,
+        }),
+      ).rejects.toThrow(/getToken is not a function/)
+    })
+  },
+)

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -27,7 +27,7 @@ import { AccessKeyStrategy } from '@cipherstash/auth/wasm-inline'
 import { beforeAll, describe, expect, test } from 'vitest'
 
 const REQUIRED_ENV = [
-  'CS_REGION',
+  'CS_WORKSPACE_CRN',
   'CS_CLIENT_ACCESS_KEY',
   'CS_CLIENT_ID',
   'CS_CLIENT_KEY',
@@ -80,18 +80,33 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
     // local consts so TS narrows away the `undefined` and the test body
     // doesn't need non-null assertions on every reference.
     const env = {
-      region: process.env.CS_REGION,
+      workspaceCrn: process.env.CS_WORKSPACE_CRN,
       accessKey: process.env.CS_CLIENT_ACCESS_KEY,
       clientId: process.env.CS_CLIENT_ID,
       clientKey: process.env.CS_CLIENT_KEY,
     }
-    if (!env.region || !env.accessKey || !env.clientId || !env.clientKey) {
+    if (
+      !env.workspaceCrn ||
+      !env.accessKey ||
+      !env.clientId ||
+      !env.clientKey
+    ) {
       throw new Error(
         'unreachable: describe.skipIf should have prevented this test from running without env vars',
       )
     }
 
-    const strategy = AccessKeyStrategy.create(env.region, env.accessKey)
+    // stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN.
+    // The wasm AccessKeyStrategy.create still takes a region string but
+    // it expects the `<region>.<provider>` form, which is the middle
+    // segment of a CRN like `crn:ap-southeast-2.aws:<workspace>`.
+    const crnMatch = env.workspaceCrn.match(/^crn:([^:]+):/)
+    if (!crnMatch) {
+      throw new Error(
+        `unexpected CS_WORKSPACE_CRN format: ${env.workspaceCrn}`,
+      )
+    }
+    const strategy = AccessKeyStrategy.create(crnMatch[1], env.accessKey)
 
     const client = await wasm.newClient({
       strategy,
@@ -100,7 +115,10 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
         tables: {
           users: {
             email: {
-              cast_as: 'string',
+              // The TS shim normalises 'string' → 'text' before handing the
+              // config to native; the wasm test bypasses that shim, so it
+              // must use the post-0.36 canonical vocabulary directly.
+              cast_as: 'text',
               indexes: { unique: {} },
             },
           },

--- a/src/index.cts
+++ b/src/index.cts
@@ -20,7 +20,10 @@ export type Client = { readonly [sym]: unknown }
 // Use this declaration to assign types to the protect-ffi's exports,
 // which otherwise default to `any`.
 declare module './load.cjs' {
-  function newClient(opts: NativeNewClientOptions): Promise<Client>
+  function newClient(
+    opts: NativeNewClientOptions,
+    strategy?: AuthStrategy,
+  ): Promise<Client>
   function encrypt(client: Client, opts: EncryptOptions): Promise<Encrypted>
   function decrypt(client: Client, opts: DecryptOptions): Promise<JsPlaintext>
   function isEncrypted(encrypted: unknown): boolean
@@ -149,10 +152,13 @@ function wrapSync<T>(fn: () => T): T {
 
 export function newClient(opts: NewClientOptions): Promise<Client> {
   return wrapAsync(() =>
-    native.newClient({
-      encryptConfig: normalizeEncryptConfig(opts.encryptConfig),
-      clientOpts: withEnvCredentials(opts.clientOpts),
-    }),
+    native.newClient(
+      {
+        encryptConfig: normalizeEncryptConfig(opts.encryptConfig),
+        clientOpts: withEnvCredentials(opts.clientOpts),
+      },
+      opts.strategy,
+    ),
   )
 }
 
@@ -441,6 +447,21 @@ export type TokenFilter = { kind: 'downcase' }
 export type NewClientOptions = {
   encryptConfig: EncryptConfig
   clientOpts?: ClientOpts
+  /**
+   * Caller-supplied auth strategy. When provided, `getToken()` is invoked on
+   * every ZeroKMS request and `clientOpts.creds` is ignored for auth (the
+   * client key is still required). Without this, the native side builds an
+   * AutoStrategy from env / profile / `clientOpts.creds`.
+   */
+  strategy?: AuthStrategy
+}
+
+/**
+ * Auth strategy shape compatible with `@cipherstash/auth` strategies (e.g.
+ * `AccessKeyStrategy`). Only `getToken` is required.
+ */
+export type AuthStrategy = {
+  getToken: () => Promise<{ token: string }>
 }
 
 /** Options passed to the native `newClient` after vocabulary normalization. */

--- a/src/index.cts
+++ b/src/index.cts
@@ -246,11 +246,6 @@ export type BulkDecryptPayload = {
   lockContext?: Context
 }
 
-export type CtsToken = {
-  accessToken: string
-  expiry: number
-}
-
 export type Context = {
   identityClaim: string[]
 }
@@ -497,26 +492,22 @@ export type EncryptOptions = {
   column: string
   table: string
   lockContext?: Context
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }
 
 export type EncryptBulkOptions = {
   plaintexts: EncryptPayload[]
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }
 
 export type DecryptOptions = {
   ciphertext: Encrypted
   lockContext?: Context
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }
 
 export type DecryptBulkOptions = {
   ciphertexts: BulkDecryptPayload[]
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }
 
@@ -532,7 +523,6 @@ export type EncryptQueryOptions = {
   indexType: IndexTypeName
   queryOp?: QueryOpName
   lockContext?: Context
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }
 
@@ -547,6 +537,5 @@ export type QueryPayload = {
 
 export type EncryptQueryBulkOptions = {
   queries: QueryPayload[]
-  serviceToken?: CtsToken
   unverifiedContext?: Record<string, unknown>
 }


### PR DESCRIPTION
## Summary

Unifies the `newClient` signature so callers can pass an `@cipherstash/auth`-shaped strategy on either target. Previously the WASM build took strategy as a separate first positional arg (`newClient(strategy, opts)`) while the Node build had no way to supply a JS-backed strategy at all.

- **WASM**: `newClient(opts)` with `opts.strategy` required (extracted via `Reflect::get` before serde — JS functions don't survive `serde_wasm_bindgen`). No env / fs fallback path exists for wasm, so the strategy stays mandatory.
- **Node**: `newClient(opts)` with `opts.strategy` optional. When supplied, a new `NeonJsAuthStrategy` adapter (`Root<JsFunction>` + a `Channel` captured at `neon::main` into a `OnceCell`) invokes the JS callable from tokio tasks; `getToken` runs on every ZeroKMS request, matching the WASM model (caching is the JS strategy's responsibility). When omitted, falls back to `AutoStrategy` built from `opts.clientOpts.creds` — same behavior as today.
- A `NodeAuthStrategy` enum wraps either variant so `Client` stays concrete and no `#[neon::export]` function needs to become generic.
- TS shim adds an `AuthStrategy` type and threads `opts.strategy` through as the second native argument.

## Test plan

- [x] `cargo build` (Node target) — clean
- [x] `npm run build:wasm` — clean (pre-existing dead-code warnings on wasm only)
- [x] `npm run test:typecheck` — clean
- [x] `cargo test` — 71 passed
- [x] Integration-test types still compile (pre-existing unrelated TS errors unchanged: 15 → 15 with/without diff)
- [ ] Run `wasm-round-trip` integration test against real creds to confirm end-to-end works with the new `opts.strategy` shape
- [ ] Smoke-test Node `newClient({ ..., strategy })` against a real `@cipherstash/auth` strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional JS-backed authentication strategy can be supplied when creating a client (Node and Wasm); public AuthStrategy type exported.

* **Breaking Changes**
  * serviceToken removed from encrypt/decrypt and query option types.
  * CtsToken type removed.
  * newClient initialization signature updated to accept an optional strategy.

* **Tests**
  * Added/expanded integration tests for JS-backed auth, error cases, and event-loop exit.

* **Chores**
  * CI and test tasks updated to ensure wasm tooling/build steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cipherstash/protectjs-ffi/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->