### PR TITLE
docs: add CHANGELOG, automate release notes, refresh README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -224,9 +224,22 @@ jobs:
         run: |
           mkdir -p dist
           echo "filename=$(npm pack --silent --pack-destination=./dist)" | tee -a $GITHUB_OUTPUT
+      - name: Extract release notes
+        if: ${{ inputs.github-release }}
+        shell: bash
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          # Source the GitHub release body from the matching CHANGELOG section.
+          # Fall back to a pointer rather than failing the release if it's absent.
+          if ! node scripts/changelog-extract.mjs "${TAG#v}" > RELEASE_NOTES.md; then
+            echo "See [CHANGELOG.md](https://github.com/cipherstash/protectjs-ffi/blob/${TAG}/CHANGELOG.md)." > RELEASE_NOTES.md
+          fi
+          cat RELEASE_NOTES.md
       - name: Release
         if: ${{ inputs.github-release }}
         uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564 # v2.0.4
         with:
           files: ./dist/${{ steps.pack.outputs.filename }}
           tag_name: ${{ inputs.tag }}
+          body_path: RELEASE_NOTES.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+While the project is pre-1.0, breaking changes are released as minor version bumps.
+
+## [0.25.0] - 2026-05-29
+
+### Breaking
+
+- Removed `serviceToken` from `EncryptOptions`, `DecryptOptions`, and the query
+  option types.
+- Removed the `CtsToken` public type export.
+- Auth environment updated for stack-auth 0.36: `CS_REGION` is dropped in favour
+  of `CS_WORKSPACE_CRN`.
+
+### Added
+
+- `newClient` now accepts an optional `opts.strategy` (an `AuthStrategy`,
+  `@cipherstash/auth`-shaped object) on **both Node and WASM**. When supplied,
+  `getToken()` is invoked on every ZeroKMS request. On WASM the strategy is
+  **required** (there is no env/filesystem fallback); on Node it is optional and
+  falls back to the `AutoStrategy` built from credentials / profile.
+
+### Fixed
+
+- Node: capture a per-isolate Neon `Channel` for the JS-backed strategy, and
+  `unref` it so scripts can exit cleanly after a round trip.
+- Node: wrap the `getToken` JS call in `Context::try_catch` so a strategy that
+  throws (or otherwise misbehaves) surfaces as a clean error instead of an
+  unhandled rejection.
+
+### Changed
+
+- Bumped `cipherstash-client`, `cts-common`, `stack-auth`, and `stack-profile`
+  to `0.36.0`.
+- Expanded integration coverage: JS-backed auth contract, event-loop-exit, and
+  `newClient` guard tests.
+
+## [0.24.0] - 2026-05-26
+
+### Added
+
+- WASM build target: a `wasm-bindgen` surface (`src/wasm.rs`), a build pipeline
+  with CI integration, and an end-to-end round-trip integration test.
+
+### Fixed
+
+- WASM: match Neon's flat API shape and drop the `@ts-self-types` directive from
+  the inline shim.
+- WASM: wrap the `client_key` hex in a `ZeroizeOnDrop` newtype from
+  deserialization, with tighter typing and zeroize for client credentials.
+- WASM: use `CanonicalEncryptionConfig` after the config refactor.
+
+### Changed
+
+- `cfg`-gate Neon-only code so `wasm32` compiles.
+- Bumped dependencies for a wasm-ready `cipherstash-client` and `vitaminc`.
+
+## [0.23.0] - 2026-05-21
+
+### Fixed
+
+- Types: split the storage `Encrypted` payload from the query payload types.
+- Types: forbid ciphertext on `EncryptedScalarQuery`.
+
+## [0.22.0] - 2026-05-20
+
+### Added
+
+- Expose the STE-vector encoding mode option.
+- Normalize encrypt config vocabulary at the FFI boundary, including a
+  `normalizeEncryptConfig` `cast_as` translation helper.
+
+### Changed
+
+- Replace the hand-rolled encrypt config with `CanonicalEncryptionConfig`
+  (see the migration notes documented in this release for breaking config
+  changes).
+- Upgrade `cipherstash-client` to `0.35.0`.
+
+[0.25.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.24.0...v0.25.0
+[0.24.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.23.0...v0.24.0
+[0.23.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.22.0...v0.23.0
+[0.22.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.21.4...v0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 While the project is pre-1.0, breaking changes are released as minor version bumps.
 
+Add notes for unreleased work under the `[Unreleased]` heading below. On
+release, the `version` npm lifecycle hook promotes that section to a dated
+release entry (see `scripts/changelog-release.mjs`), and the release workflow
+uses the promoted section as the GitHub release notes.
+
+## [Unreleased]
+
 ## [0.25.0] - 2026-05-29
 
 ### Breaking
@@ -81,6 +88,7 @@ While the project is pre-1.0, breaking changes are released as minor version bum
   changes).
 - Upgrade `cipherstash-client` to `0.35.0`.
 
+[Unreleased]: https://github.com/cipherstash/protectjs-ffi/compare/v0.25.0...HEAD
 [0.25.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/cipherstash/protectjs-ffi/compare/v0.22.0...v0.23.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Protect.js CipherStash Client FFI
 
 > [!IMPORTANT]
-> If you are looking to implement this package into your application please use the official [protect package](https://github.com/cipherstash/protectjs).
+> If you are looking to implement this package into your application please use the official [`@cipherstash/stack` package](https://www.npmjs.com/package/@cipherstash/stack) (formerly Protect.js). This repository provides the lower-level FFI bindings it builds on.
 
 This project provides the JS bindings for the CipherStash Client Rust SDK and is bootstrapped by [create-neon](https://www.npmjs.com/package/create-neon).
 
@@ -19,14 +19,13 @@ This command uses the [@neon-rs/cli](https://www.npmjs.com/package/@neon-rs/cli)
 
 ## Local setup
 
-You can use the `stash` CLI tool to set up your local environment.
-
-You will be prompted to sign in or create an account and follow steps to create a keyset and client key.
+Authenticate the `stash` CLI to set up your local environment. It runs via `npx` — no separate install needed:
 
 ```sh
-brew install cipherstash/tap/stash
-stash setup
+npx stash auth login
 ```
+
+You will be prompted to sign in or create an account.
 
 ## Exploring
 
@@ -200,8 +199,11 @@ To perform a release:
    Select "custom" in the dropdown and fill in the "Custom version" text box if you want to use a semver string instead of the shorthand (patch, minor, major, etc.).
 1. Click "Run workflow".
 
-Note that we currently don't have any automation around release notes or a changelog.
-However, you can add release notes after running the workflow by editing the release on GitHub.
+Release notes and the changelog are automated. Add notes for your changes under the
+`[Unreleased]` heading in [`CHANGELOG.md`](./CHANGELOG.md). On release, the `version`
+npm lifecycle hook promotes that section to a dated release entry
+(`scripts/changelog-release.mjs`), and the workflow publishes the promoted section as
+the GitHub release notes (`scripts/changelog-extract.mjs`).
 
 ## Learn More
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cross": "npm run cross-build -- --release",
     "zigbuild": "npm run zig-build -- --release",
     "prepack": "tsc &&neon update",
-    "version": "neon bump --binaries platforms && git add .",
+    "version": "neon bump --binaries platforms && node scripts/changelog-release.mjs && git add .",
     "release": "gh workflow run release.yml -f dryrun=false -f version=patch",
     "dryrun": "gh workflow run publish.yml -f dryrun=true",
     "build:wasm": "wasm-pack build crates/protect-ffi --target bundler --out-dir ../../dist/wasm --no-pack",

--- a/scripts/changelog-extract.mjs
+++ b/scripts/changelog-extract.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// Print the CHANGELOG.md section body for a given version, for use as GitHub
+// release notes. Usage: node scripts/changelog-extract.mjs 0.26.0
+//
+// Exits non-zero if the section is missing so the caller can fall back to a
+// generic body rather than publishing an empty release.
+import { readFileSync } from 'node:fs'
+
+const version = (process.argv[2] || '').replace(/^v/, '')
+if (!version) {
+  console.error('usage: changelog-extract.mjs <version>')
+  process.exit(2)
+}
+
+const text = readFileSync('CHANGELOG.md', 'utf8')
+const escaped = version.replace(/\./g, '\\.')
+// Match the version heading, then capture until the next `## [` section or the
+// link-reference block (`[x]: ...`) at the bottom.
+const re = new RegExp(
+  `## \\[${escaped}\\][^\\n]*\\n([\\s\\S]*?)(?=\\n## \\[|\\n\\[[^\\]]+\\]:|$)`,
+)
+const match = text.match(re)
+if (!match) {
+  console.error(`changelog-extract: no section for ${version}`)
+  process.exit(1)
+}
+
+process.stdout.write(`${match[1].trim()}\n`)

--- a/scripts/changelog-release.mjs
+++ b/scripts/changelog-release.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Promote the `[Unreleased]` section of CHANGELOG.md to a dated release entry
+// for the version currently being released.
+//
+// Invoked from the `version` npm lifecycle hook (see package.json), so it runs
+// automatically during `npm version` — both in CI releases and local bumps —
+// after the package version has been bumped but before the version commit. The
+// hook's trailing `git add .` stages the result into that commit, so the tag
+// always carries an up-to-date CHANGELOG.
+//
+// Defensive by design: anything unexpected (no version, no `[Unreleased]`
+// heading, already-promoted) logs and exits 0 so a release is never blocked.
+import { readFileSync, writeFileSync } from 'node:fs'
+
+const REPO = 'https://github.com/cipherstash/protectjs-ffi'
+const FILE = 'CHANGELOG.md'
+
+const version = (
+  process.env.npm_package_version ||
+  process.argv[2] ||
+  ''
+).replace(/^v/, '')
+if (!version) {
+  console.warn(
+    'changelog-release: no version (npm_package_version unset) — skipping',
+  )
+  process.exit(0)
+}
+
+let text = readFileSync(FILE, 'utf8')
+
+if (text.includes(`## [${version}]`)) {
+  console.log(`changelog-release: [${version}] already present — skipping`)
+  process.exit(0)
+}
+
+// Capture everything under `## [Unreleased]` up to the next `## [` section
+// heading or the link-reference block at the bottom.
+const unreleasedRe =
+  /## \[Unreleased\]\n([\s\S]*?)(?=\n## \[|\n\[Unreleased\]:|$)/
+const match = text.match(unreleasedRe)
+if (!match) {
+  console.warn('changelog-release: no [Unreleased] section — skipping')
+  process.exit(0)
+}
+
+const body = match[1].trim() || '- _No notable changes documented._'
+const today = new Date().toISOString().slice(0, 10)
+
+// Previous released version = first `## [x.y.z]` heading (the topmost release).
+const prevMatch = text.match(/## \[(\d+\.\d+\.\d+)\]/)
+const prev = prevMatch ? prevMatch[1] : null
+
+// Reset `[Unreleased]` to empty and insert the promoted, dated section below it.
+text = text.replace(
+  unreleasedRe,
+  `## [Unreleased]\n\n## [${version}] - ${today}\n\n${body}\n`,
+)
+
+// Point the `[Unreleased]` compare link at the new tag, and add a link for the
+// freshly promoted version directly beneath it.
+const newLink = `[${version}]: ${REPO}/compare/${prev ? `v${prev}` : `v${version}^`}...v${version}`
+text = text
+  .replace(
+    /\[Unreleased\]:.*/,
+    `[Unreleased]: ${REPO}/compare/v${version}...HEAD`,
+  )
+  .replace(/(\[Unreleased\]:.*\n)/, `$1${newLink}\n`)
+
+writeFileSync(FILE, text)
+console.log(
+  `changelog-release: promoted [Unreleased] -> [${version}] - ${today}`,
+)


### PR DESCRIPTION
Adds a `CHANGELOG.md` (the repo had none), automates changelog/release-notes upkeep, and refreshes the stale README.

## CHANGELOG
- New `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, with `0.25.0` seeded and `0.24.0`/`0.23.0`/`0.22.0` backfilled from git history.
- An `[Unreleased]` section is the place contributors add notes.

## Release-notes automation
- `scripts/changelog-release.mjs` runs inside the existing `version` npm lifecycle hook (`neon bump … && node scripts/changelog-release.mjs && git add .`). On `npm version` it promotes `[Unreleased]` to a dated entry and updates the compare links — so the tagged release commit always carries an up-to-date CHANGELOG. No `release.yml` changes needed.
- `scripts/changelog-extract.mjs` prints a version's section; the release workflow's `main` job feeds it to `softprops/action-gh-release` via `body_path`, so GitHub release notes come straight from the CHANGELOG (falls back to a CHANGELOG link if the section is missing — never blocks a release).
- Both scripts are defensive (skip cleanly on missing version/section/already-promoted) and were tested locally against a simulated `0.26.0` bump (empty + populated `[Unreleased]`, idempotency, missing-version).

## README
- Point consumers at the renamed **`@cipherstash/stack`** package (formerly Protect.js).
- Local setup now uses **`npx stash auth login`** instead of the brew-installed Rust `stash` CLI.
- Replace the "no changelog automation" note with the new flow.

## Validation note
The `version`-hook promotion is exercised by any `npm version` (including a release **dry run**). The `body_path` release-notes wiring only runs on a real publish, so it'll be first exercised on the next actual release.

(0.25.0 was released manually; its notes were added by hand. This makes the *next* release automatic.)