### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,13 +63,13 @@ jobs:
         # configured on npmjs.com for this repo + release.yml — no NPM_TOKEN
         # secret is required. See the publish job below.
         run: echo publish=true | tee -a $GITHUB_OUTPUT
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         id: app-token
         with:
           app-id: ${{ vars.PUBLISHER_APP_ID }}
           private-key: ${{ secrets.PUBLISHER_SECRET_KEY }}
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
@@ -111,20 +111,21 @@ jobs:
     # build matrix above stays on Blacksmith.
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       id-token: write # Required for npm OIDC trusted publishing
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.setup.outputs.ref }}
+          persist-credentials: false
       # OIDC trusted publishing needs Node >= 22.14 and npm >= 11.5.1, and must
       # NOT have a token .npmrc. Use setup-node WITHOUT registry-url (the Neon
       # setup action sets registry-url, which writes a //registry/:_authToken
       # line that shadows OIDC) — this job only publishes prebuilt tarballs, so
       # it needs no Rust toolchain or npm install.
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22
       - name: Upgrade npm for OIDC trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           app-id: ${{ vars.PUBLISHER_APP_ID }}
           private-key: ${{ secrets.PUBLISHER_SECRET_KEY }}
+          # Least privilege: the token is only used to checkout and
+          # `git push --follow-tags` in the Tag Release step below.
+          permission-contents: write
       - name: Checkout Code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,22 +59,10 @@ jobs:
         name: Validate Publish Event
         if: ${{ !inputs.dryrun }}
         shell: bash
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          if [[ -z $NPM_TOKEN ]]; then
-            echo "::error::Secret NPM_TOKEN is not defined for this GitHub repo."
-            echo "::error::To publish to npm, this action requires:"
-            echo "::error:: • an npm access token;"
-            echo "::error:: • with Read-Write access to this project's npm packages;"
-            echo "::error:: • stored as a repo secret named NPM_TOKEN."
-            echo "::error::See https://docs.npmjs.com/about-access-tokens for info about creating npm tokens."
-            echo "::error:: 💡 The simplest method is to create a Classic npm token of type Automation."
-            echo "::error:: 💡 For greater security, consider using a Granual access token."
-            echo "::error::See https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions for info about how to store GitHub repo secrets."
-            exit 1
-          fi
-          echo publish=true | tee -a $GITHUB_OUTPUT
+        # Publishing authenticates via npm OIDC trusted publishing, which is
+        # configured on npmjs.com for this repo + release.yml — no NPM_TOKEN
+        # secret is required. See the publish job below.
+        run: echo publish=true | tee -a $GITHUB_OUTPUT
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
@@ -117,18 +105,30 @@ jobs:
     name: Publish
     if: ${{ needs.setup.outputs.publish }}
     needs: [setup, build]
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    # GitHub-hosted (not Blacksmith): npm only accepts provenance attestations
+    # from github-hosted runners (self-hosted is rejected with E422). This job
+    # only publishes prebuilt tarballs, so it doesn't need Blacksmith — the
+    # build matrix above stays on Blacksmith.
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write # Required for npm OIDC trusted publishing
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.setup.outputs.ref }}
-      - name: Setup Neon Environment
-        uses: ./.github/actions/setup
+      # OIDC trusted publishing needs Node >= 22.14 and npm >= 11.5.1, and must
+      # NOT have a token .npmrc. Use setup-node WITHOUT registry-url (the Neon
+      # setup action sets registry-url, which writes a //registry/:_authToken
+      # line that shadows OIDC) — this job only publishes prebuilt tarballs, so
+      # it needs no Rust toolchain or npm install.
+      - name: Install Node.js
+        uses: actions/setup-node@v4
         with:
-          use-rust: false
+          node-version: 22
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@^11.5.1
       - name: Fetch
         uses: robinraju/release-downloader@c39a3b234af58f0cf85888573d361fb6fa281534 # v1.10
         with:
@@ -137,9 +137,10 @@ jobs:
           out-file-path: ./dist
       - name: Publish
         shell: bash
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        # No NODE_AUTH_TOKEN — authenticate via OIDC trusted publishing.
+        # --provenance generates a signed provenance attestation; the repo is
+        # public and every package sets repository.url, which provenance needs.
         run: |
           for p in ./dist/*.tgz ; do
-            npm publish --access public $p
+            npm publish --access public --provenance "$p"
           done

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prepack": "tsc &&neon update",
     "version": "neon bump --binaries platforms && git add .",
     "release": "gh workflow run release.yml -f dryrun=false -f version=patch",
-    "dryrun": "gh workflow run publish.yml -f dryrun=true",
+    "dryrun": "gh workflow run release.yml -f dryrun=true -f version=patch",
     "build:wasm": "wasm-pack build crates/protect-ffi --target bundler --out-dir ../../dist/wasm --no-pack",
     "postbuild:wasm": "node scripts/inline-wasm.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,14 @@
 {
   "name": "@cipherstash/protect-ffi",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git"
+  },
+  "bugs": {
+    "url": "https://github.com/cipherstash/protectjs-ffi/issues"
+  },
+  "homepage": "https://github.com/cipherstash/protectjs-ffi#readme",
   "description": "",
   "main": "./lib/index.cjs",
   "scripts": {

--- a/platforms/darwin-arm64/package.json
+++ b/platforms/darwin-arm64/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-darwin-arm64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-arm64`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/darwin-arm64"
+  },
   "os": [
     "darwin"
   ],

--- a/platforms/darwin-x64/package.json
+++ b/platforms/darwin-x64/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-darwin-x64",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `darwin-x64`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/darwin-x64"
+  },
   "os": [
     "darwin"
   ],

--- a/platforms/linux-arm64-gnu/package.json
+++ b/platforms/linux-arm64-gnu/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-linux-arm64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-arm64-gnu`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/linux-arm64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-gnu/package.json
+++ b/platforms/linux-x64-gnu/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-linux-x64-gnu",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-gnu`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/linux-x64-gnu"
+  },
   "os": [
     "linux"
   ],

--- a/platforms/linux-x64-musl/package.json
+++ b/platforms/linux-x64-musl/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-linux-x64-musl",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `linux-x64-musl`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/linux-x64-musl"
+  },
   "os": [
     "linux"
   ],

--- a/platforms/win32-x64-msvc/package.json
+++ b/platforms/win32-x64-msvc/package.json
@@ -2,6 +2,11 @@
   "name": "@cipherstash/protect-ffi-win32-x64-msvc",
   "description": "Prebuilt binary package for `@cipherstash/protect-ffi` on `win32-x64-msvc`.",
   "version": "0.25.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/cipherstash/protectjs-ffi.git",
+    "directory": "platforms/win32-x64-msvc"
+  },
   "os": [
     "win32"
   ],


### PR DESCRIPTION
## Why

`@cipherstash/protect-ffi` and its six `@cipherstash/protect-ffi-<platform>` binary packages publish from this repo using a long-lived `NPM_TOKEN` — the same class of token npm just revoked on `cipherstash/stack`, which broke that repo's releases. This migrates to **npm OIDC trusted publishing** (short-lived, no stored secret) with **provenance**.

## Changes

**`release.yml` — `publish` job**
- Add `id-token: write`.
- Drop `NODE_AUTH_TOKEN` and the Neon setup action. The Neon setup runs `setup-node` with `registry-url`, which writes a `//registry.npmjs.org/:_authToken=…` line that shadows OIDC. The publish job only ships prebuilt tarballs, so it needs no Rust toolchain or `npm ci` — replaced with a plain `setup-node` (Node 22, **no** `registry-url`) + `npm install -g npm@^11.5.1` (OIDC needs npm ≥ 11.5.1 / Node ≥ 22.14).
- Publish with `npm publish --access public --provenance`.
- Run on **`ubuntu-latest`** (github-hosted): npm only accepts provenance from github-hosted runners (self-hosted → E422). The Rust build matrix stays on Blacksmith.

**`release.yml` — `setup` job**
- Remove the `NPM_TOKEN` presence check (it would fail the release once the secret is removed).

**`repository` fields**
- Add `repository` (url + per-package `directory`) to the root package and all six `platforms/*/package.json`. Provenance validation requires `repository.url` to match this repo.

## Required on npmjs.com before this can publish

Configure a **Trusted Publisher** (org `cipherstash`, repo `protectjs-ffi`, workflow `release.yml`) for **all seven** packages:
`@cipherstash/protect-ffi`, `@cipherstash/protect-ffi-darwin-x64`, `-darwin-arm64`, `-win32-x64-msvc`, `-linux-x64-gnu`, `-linux-arm64-gnu`, `-linux-x64-musl`.

> The current `NPM_TOKEN`-based pipeline keeps working until then, so this can merge and be exercised on the next `workflow_dispatch` release once the publishers are set up. ⚠️ Verify a release after merge — this pipeline publishes prebuilt tarballs downloaded from the GitHub Release, and provenance-from-tarball is exercised here for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched npm publishing to OIDC-based trusted publishing with improved security and signed provenance for published artifacts.
  * Added and standardized package metadata (repository, issue tracker, homepage) across the primary package and all platform-specific distributions for better discovery and transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->