### PR TITLE
chore: bump cipherstash-client and stack-auth to 0.37.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-client"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6b9666c5397e1feeabe3f0212446ff362d27fc2062c9d12807c7400fb83f3c"
+checksum = "92b2a6d270736b771a4aa1b722056ccc37cd1702b8d7d02516b5a9db07fb6dff"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
@@ -610,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-config"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9f36a62fdb1abf225c1072d460d22fff4da4deebe0781ff1ecbee3261e0cff"
+checksum = "f1e92e955c0acbf6e3e756a086fe421e0cb0ebe95a4c17720e518fe5588e38f7"
 dependencies = [
  "bitflags",
  "serde",
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "cipherstash-core"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1a3f1483fd420059935764fea971869f39a6e025edf10cfb2a2ca7594ac2b8"
+checksum = "17d8a0a132e93e6befd06f368653b53455fb8dda464c27619350cf7fbd422550"
 dependencies = [
  "getrandom 0.2.17",
  "hmac",
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "cts-common"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d924055250a6dcd4a67a490e9bf9fe26dff9ab8b40ab5f4a60a3e6e03569b0e"
+checksum = "e06ab47689bcb9d81bc9b8c9ca4595b85a00b90b0e6086156f3ad569ecd6b6af"
 dependencies = [
  "arrayvec",
  "base32",
@@ -3273,9 +3273,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stack-auth"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c95d236e8c5e48d89ff181af6b0bcff2519d65f455563aff762c0ab80dbb63"
+checksum = "05b4a66d6258dad2af5bf2f12672d9de7f465cb8f503653ac55d9e3bc061815f"
 dependencies = [
  "aquamarine",
  "base64",
@@ -3301,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "stack-profile"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7384df859a75bf6b282fbd8ddad139abffa28a4d128dce402f8ee4130815f2"
+checksum = "92cb195d25669b405f715afffc281596f2c9cf6da1a73ef4750513d4e57d77ab"
 dependencies = [
  "dirs",
  "gethostname",
@@ -4876,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "zerokms-protocol"
-version = "0.12.16"
+version = "0.12.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f279d7e22849e3b5f3e3809a3b77ee36456e1bb35190eb494a564c2a94e4454"
+checksum = "3b8279b143cf2a26648bc7b8a14725f4d78d2a41a3a95e50b10d6f90e71bb481"
 dependencies = [
  "base64",
  "cipherstash-config",

--- a/crates/protect-ffi/Cargo.toml
+++ b/crates/protect-ffi/Cargo.toml
@@ -10,9 +10,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 chrono = { version = "0.4.42", default-features = false, features = ["serde"] }
-cipherstash-client = { version = "=0.36.0", features = ["tokio"] }
-cts-common = { version = "=0.36.0", default-features = false }
-stack-auth = { version = "=0.36.0" }
+cipherstash-client = { version = "=0.37.0", features = ["tokio"] }
+cts-common = { version = "=0.37.0", default-features = false }
+stack-auth = { version = "=0.37.0" }
 hex = "0.4.3"
 once_cell = "1.20.2"
 rust_decimal = "1.37"
@@ -25,7 +25,7 @@ zeroize = { version = "1.8", features = ["derive"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 neon = { version = "1", features = ["serde", "tokio"] }
-stack-profile = { version = "=0.36.0" }
+stack-profile = { version = "=0.37.0" }
 tokio = { version = "1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cipherstash/auth": "^0.38.0",
+        "@cipherstash/auth": "^0.39.0",
         "@cipherstash/protect-ffi": "..",
         "pg": "^8.13.3"
       },
@@ -23,7 +23,7 @@
     },
     "..": {
       "name": "@cipherstash/protect-ffi",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "ISC",
       "dependencies": {
         "@neon-rs/load": "^0.1.82"
@@ -112,16 +112,16 @@
       }
     },
     "node_modules/@cipherstash/auth": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@cipherstash/auth/-/auth-0.38.0.tgz",
-      "integrity": "sha512-jsrJ8fqenjcuMGWG1pBzVUflZUQZ7c1MosYiqyxh6fYDsMlTl70S8agDSsa2ciXmVQyti49n4on8c1CZxGhF5w==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@cipherstash/auth/-/auth-0.39.0.tgz",
+      "integrity": "sha512-pn2HhF8T1xZdEOpHlOb9hamFwKI/r0gYaKZEswnTyjOahIT5uqV86M7Iu4Py4n88pAMRZUsvW7h1r5I3zBsFdg==",
       "peerDependencies": {
-        "@cipherstash/auth-darwin-arm64": "0.38.0",
-        "@cipherstash/auth-darwin-x64": "0.38.0",
-        "@cipherstash/auth-linux-arm64-gnu": "0.38.0",
-        "@cipherstash/auth-linux-x64-gnu": "0.38.0",
-        "@cipherstash/auth-linux-x64-musl": "0.38.0",
-        "@cipherstash/auth-win32-x64-msvc": "0.38.0"
+        "@cipherstash/auth-darwin-arm64": "0.39.0",
+        "@cipherstash/auth-darwin-x64": "0.39.0",
+        "@cipherstash/auth-linux-arm64-gnu": "0.39.0",
+        "@cipherstash/auth-linux-x64-gnu": "0.39.0",
+        "@cipherstash/auth-linux-x64-musl": "0.39.0",
+        "@cipherstash/auth-win32-x64-msvc": "0.39.0"
       },
       "peerDependenciesMeta": {
         "@cipherstash/auth-darwin-arm64": {

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "description": "",
   "dependencies": {
-    "@cipherstash/auth": "^0.38.0",
+    "@cipherstash/auth": "^0.39.0",
     "@cipherstash/protect-ffi": "..",
     "pg": "^8.13.3"
   },

--- a/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
+++ b/integration-tests/tests/fixtures/event-loop-exit-jsbacked.cjs
@@ -24,11 +24,9 @@ const encryptConfig = {
   // Use the wasm-inline build of @cipherstash/auth — it has no native
   // binary dep, works on any Node target, and lets us exercise the
   // `opts.strategy` (JsBacked) code path with a real getToken.
-  // Note: stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN;
-  // the wasm AccessKeyStrategy.create still takes a region string as its
-  // first argument (named that way in the .d.ts) but expects the
-  // <region>.<provider> form, which is the middle segment of a CRN like
-  // `crn:ap-southeast-2.aws:<workspace>`.
+  // @cipherstash/auth 0.39 takes the full workspace CRN and parses the
+  // region from it (earlier versions took only the `<region>.<provider>`
+  // segment, requiring callers to split the CRN themselves).
   const { AccessKeyStrategy } = await import('@cipherstash/auth/wasm-inline')
   const accessKey = process.env.CS_CLIENT_ACCESS_KEY
   const workspaceCrn = process.env.CS_WORKSPACE_CRN
@@ -37,12 +35,7 @@ const encryptConfig = {
       'event-loop-exit-jsbacked fixture needs CS_CLIENT_ACCESS_KEY and CS_WORKSPACE_CRN',
     )
   }
-  const match = workspaceCrn.match(/^crn:([^:]+):/)
-  if (!match) {
-    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${workspaceCrn}`)
-  }
-  const region = match[1]
-  const strategy = AccessKeyStrategy.create(region, accessKey)
+  const strategy = AccessKeyStrategy.create(workspaceCrn, accessKey)
 
   const client = await newClient({ encryptConfig, strategy })
 

--- a/integration-tests/tests/js-strategy.test.ts
+++ b/integration-tests/tests/js-strategy.test.ts
@@ -38,14 +38,10 @@ function buildAccessKeyStrategy(): AccessKeyStrategy {
   if (!crn || !accessKey) {
     throw new Error('unreachable: skipIf gates this')
   }
-  // stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN; the
-  // wasm AccessKeyStrategy.create still takes a region string but expects
-  // the `<region>.<provider>` middle segment of the CRN.
-  const match = crn.match(/^crn:([^:]+):/)
-  if (!match) {
-    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${crn}`)
-  }
-  return AccessKeyStrategy.create(match[1], accessKey)
+  // @cipherstash/auth 0.39 takes the full workspace CRN and parses the
+  // region from it (earlier versions took only the `<region>.<provider>`
+  // segment, requiring callers to split the CRN themselves).
+  return AccessKeyStrategy.create(crn, accessKey)
 }
 
 const clientOpts: ClientOpts = {

--- a/integration-tests/tests/oidc-federation.test.ts
+++ b/integration-tests/tests/oidc-federation.test.ts
@@ -1,0 +1,119 @@
+// Pending scaffold for the `OidcFederation` auth strategy.
+//
+// `stack-auth` introduced an `OidcFederation` strategy, surfaced to JS via
+// `@cipherstash/auth`. From protect-ffi's perspective it is just another
+// `opts.strategy` — the native boundary duck-types on the
+// `AuthStrategy = { getToken: () => Promise<{ token: string }> }` contract
+// (see `src/index.cts`) and never branches on the concrete strategy type.
+// So there is nothing new to test on the FFI side; the coverage that matters
+// is consumer-side wiring, and it mirrors `js-strategy.test.ts` (Neon path)
+// and `wasm-round-trip.test.ts` (wasm path).
+//
+// # Why most of this file is skipped
+//
+// The hermetic end-to-end coverage is blocked on two upstream additions in
+// `@cipherstash/auth` (tracked in cipherstash/cipherstash-suite):
+//
+//   1. `OidcFederation` is not exported yet by the installed auth build
+//      (0.38.0 exposes only AutoStrategy / AccessKeyStrategy / OAuthStrategy
+//      on the node entry, and AccessKeyStrategy on `wasm-inline`).
+//   2. `MockAuthServer` only mocks the device-code / OAuth endpoints
+//      (`/oauth/device/token`, `/create-client`). A hermetic federation test
+//      needs a mock for the OIDC token-*exchange* endpoint plus a base-URL
+//      override on `OidcFederation.create(...)` (a `test-utils`-gated variant,
+//      the same pattern as `beginDeviceCodeFlowWithBaseUrl`).
+//
+// Until those land, the hermetic block below stays `describe.skip` so it
+// documents the intended shape without executing against an API that does
+// not exist. The live block at the bottom exercises the part that is real
+// today: the FFI accepts and drives any `getToken`-shaped strategy, and a
+// rejected token propagates as a client error — the contract `OidcFederation`
+// will satisfy. It needs no credentials and no network (the strategy guards
+// run before serde and before any ZeroKMS call).
+//
+// TODO(auth bump): once `@cipherstash/auth` exports `OidcFederation` and
+// `MockAuthServer` gains an OIDC-exchange mock + base-URL override, replace
+// the placeholder strategy with the real one, drop the `.skip`, and gate on
+// the export existing (see `hasOidcFederation` below) instead of skipping
+// unconditionally.
+
+import 'dotenv/config'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type AuthStrategy,
+  type ClientOpts,
+  newClient,
+} from '@cipherstash/protect-ffi'
+
+import { encryptConfig } from './common.js'
+
+const clientOpts: ClientOpts = {
+  clientId: process.env.CS_CLIENT_ID,
+  clientKey: process.env.CS_CLIENT_KEY,
+}
+
+// Flips to `true` once the auth package exports the strategy. Used to gate
+// the hermetic block in place of the unconditional `.skip` after the bump.
+//
+// import * as auth from '@cipherstash/auth'
+// const hasOidcFederation = typeof (auth as { OidcFederation?: unknown }).OidcFederation === 'function'
+const hasOidcFederation = false
+
+// ---------------------------------------------------------------------------
+// Hermetic end-to-end — PENDING the auth-package additions described above.
+// ---------------------------------------------------------------------------
+describe.skip('OidcFederation (hermetic, pending auth bump)', () => {
+  test('round-trips encrypt/decrypt via a mocked OIDC exchange', async () => {
+    // const mock = await MockAuthServer.start()
+    // mock.mockOidcExchangeEndpoint()   // upstream addition
+    // mock.mockCreateClientEndpoint()
+    //
+    // const strategy = OidcFederation.createWithBaseUrl(
+    //   { issuer: 'https://issuer.test', audience: 'cipherstash', token: 'fake.id.jwt' },
+    //   mock.baseUrl,                    // test-utils override
+    // )
+    //
+    // const client = await newClient({ encryptConfig, clientOpts, strategy })
+    // const ciphertext = await encrypt(client, {
+    //   plaintext: 'alice@example.com', table: 'users', column: 'email',
+    // })
+    // expect(isEncrypted(ciphertext)).toBe(true)
+    // expect(await decrypt(client, { ciphertext })).toBe('alice@example.com')
+    expect(hasOidcFederation).toBe(true)
+  })
+
+  test('surfaces a rejected OIDC exchange as a client error', async () => {
+    // const mock = await MockAuthServer.start()
+    // mock.mockTokenEndpointError('invalid_grant', 'expired id token')
+    // const strategy = OidcFederation.createWithBaseUrl(/* … */, mock.baseUrl)
+    // await expect(
+    //   newClient({ encryptConfig, clientOpts, strategy }),
+    // ).rejects.toThrow(/invalid_grant|expired/)
+    expect(hasOidcFederation).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Live today — the FFI strategy contract `OidcFederation` plugs into. No
+// credentials or network: the strategy shape is validated, and `getToken`
+// rejections propagate, before any ZeroKMS call. This is the same guarantee
+// `js-strategy.test.ts` proves generically; kept here as an OIDC-labelled
+// anchor so the contract is asserted against the exact `opts.strategy` path
+// the real `OidcFederation` will travel.
+// ---------------------------------------------------------------------------
+describe('OidcFederation strategy contract', () => {
+  test('a rejected getToken propagates as a client error', async () => {
+    // Stand-in for `OidcFederation` until it is exported: any object
+    // satisfying `AuthStrategy` reaches the same native code path.
+    const strategy: AuthStrategy = {
+      async getToken() {
+        throw new Error('OIDC exchange failed (placeholder for OidcFederation)')
+      },
+    }
+
+    await expect(
+      newClient({ encryptConfig, clientOpts, strategy }),
+    ).rejects.toThrow(/OIDC exchange failed/)
+  })
+})

--- a/integration-tests/tests/oidc-federation.test.ts
+++ b/integration-tests/tests/oidc-federation.test.ts
@@ -78,10 +78,11 @@ describe('OidcFederation strategy contract', () => {
       () => 'third-party.oidc.jwt',
     )
 
-    expect(typeof strategy.getToken).toBe('function')
-    // It satisfies the FFI's structural `AuthStrategy` contract.
+    // Compile-time: the wasm strategy is structurally assignable to the FFI's
+    // `AuthStrategy`. Runtime: `getToken` — the only member the FFI calls — is
+    // callable on that contract-typed handle.
     const asStrategy: AuthStrategy = strategy
-    expect(asStrategy).toBeDefined()
+    expect(typeof asStrategy.getToken).toBe('function')
   })
 
   test('a rejected getToken propagates as a client error', async () => {
@@ -128,11 +129,17 @@ describe.skipIf(missingE2eEnv.length > 0)('OidcFederation end-to-end', () => {
 
     // `getJwt` is re-invoked on every (re-)federation; here it just returns the
     // pre-minted token from the environment.
-    const strategy = OidcFederationStrategy.create(
+    const federation = OidcFederationStrategy.create(
       region,
       workspaceId,
       () => jwt,
     )
+
+    // Hand the Neon `newClient` a plain `{ getToken }` object rather than the
+    // wasm-bindgen class instance directly. The JsBacked path is proven against
+    // this shape (js-strategy.test.ts); passing a wasm class straight through is
+    // untested. The arrow keeps `getToken` bound to its wasm `this`.
+    const strategy: AuthStrategy = { getToken: () => federation.getToken() }
 
     const client = await newClient({ encryptConfig, clientOpts, strategy })
 

--- a/integration-tests/tests/oidc-federation.test.ts
+++ b/integration-tests/tests/oidc-federation.test.ts
@@ -1,48 +1,48 @@
-// Pending scaffold for the `OidcFederation` auth strategy.
+// Coverage for the `OidcFederation` auth strategy.
 //
-// `stack-auth` introduced an `OidcFederation` strategy, surfaced to JS via
-// `@cipherstash/auth`. From protect-ffi's perspective it is just another
-// `opts.strategy` — the native boundary duck-types on the
+// `stack-auth` introduced an `OidcFederationStrategy` that federates a
+// third-party OIDC JWT (Clerk, Supabase, …) into a CipherStash CTS service
+// token via `POST /api/authorise`. It is surfaced to JS by `@cipherstash/auth`
+// (>= 0.39.0) on both the node and `wasm-inline` entries.
+//
+// From protect-ffi's perspective it is just another `opts.strategy`: the
+// native boundary duck-types on the
 // `AuthStrategy = { getToken: () => Promise<{ token: string }> }` contract
-// (see `src/index.cts`) and never branches on the concrete strategy type.
-// So there is nothing new to test on the FFI side; the coverage that matters
-// is consumer-side wiring, and it mirrors `js-strategy.test.ts` (Neon path)
-// and `wasm-round-trip.test.ts` (wasm path).
+// (see `src/index.cts`) and never branches on the concrete strategy type. So
+// there is nothing new to test on the FFI side — the coverage that matters is
+// consumer-side wiring, mirroring `js-strategy.test.ts` (Neon path) and
+// `wasm-round-trip.test.ts` (wasm path).
 //
-// # Why most of this file is skipped
+// # Two tiers
 //
-// The hermetic end-to-end coverage is blocked on two upstream additions in
-// `@cipherstash/auth` (tracked in cipherstash/cipherstash-suite):
+//   1. Contract (runs in CI today, no credentials, no network): the real
+//      published `OidcFederationStrategy` constructs via its `.create` factory
+//      and exposes `getToken`, and a `getToken`-shaped strategy threads through
+//      protect-ffi's `newClient` with rejections propagating as client errors.
 //
-//   1. `OidcFederation` is not exported yet by the installed auth build
-//      (0.38.0 exposes only AutoStrategy / AccessKeyStrategy / OAuthStrategy
-//      on the node entry, and AccessKeyStrategy on `wasm-inline`).
-//   2. `MockAuthServer` only mocks the device-code / OAuth endpoints
-//      (`/oauth/device/token`, `/create-client`). A hermetic federation test
-//      needs a mock for the OIDC token-*exchange* endpoint plus a base-URL
-//      override on `OidcFederation.create(...)` (a `test-utils`-gated variant,
-//      the same pattern as `beginDeviceCodeFlowWithBaseUrl`).
+//   2. End-to-end (gated on OIDC env): a real federation round-trip —
+//      third-party JWT → CTS token → encrypt → decrypt. `describe.skipIf` keeps
+//      it a no-op until the env vars below are set, matching how every other
+//      credentialed suite behaves.
 //
-// Until those land, the hermetic block below stays `describe.skip` so it
-// documents the intended shape without executing against an API that does
-// not exist. The live block at the bottom exercises the part that is real
-// today: the FFI accepts and drives any `getToken`-shaped strategy, and a
-// rejected token propagates as a client error — the contract `OidcFederation`
-// will satisfy. It needs no credentials and no network (the strategy guards
-// run before serde and before any ZeroKMS call).
-//
-// TODO(auth bump): once `@cipherstash/auth` exports `OidcFederation` and
-// `MockAuthServer` gains an OIDC-exchange mock + base-URL override, replace
-// the placeholder strategy with the real one, drop the `.skip`, and gate on
-// the export existing (see `hasOidcFederation` below) instead of skipping
-// unconditionally.
+// A fully *hermetic* round-trip via `@cipherstash/auth`'s `MockAuthServer` is
+// not possible through the published consumer API: the mock is napi-only (the
+// integration tests run on the `wasm-inline` entry) and the public
+// `OidcFederationStrategy.create` exposes no base-URL override to point a
+// strategy at the mock (that override is `test-utils`-gated inside stack-auth
+// and used only by its own internal tests). Hence the live exchange is
+// env-gated rather than mocked.
 
 import 'dotenv/config'
+import { OidcFederationStrategy } from '@cipherstash/auth/wasm-inline'
 import { describe, expect, test } from 'vitest'
 
 import {
   type AuthStrategy,
   type ClientOpts,
+  decrypt,
+  encrypt,
+  isEncrypted,
   newClient,
 } from '@cipherstash/protect-ffi'
 
@@ -53,67 +53,97 @@ const clientOpts: ClientOpts = {
   clientKey: process.env.CS_CLIENT_KEY,
 }
 
-// Flips to `true` once the auth package exports the strategy. Used to gate
-// the hermetic block in place of the unconditional `.skip` after the bump.
-//
-// import * as auth from '@cipherstash/auth'
-// const hasOidcFederation = typeof (auth as { OidcFederation?: unknown }).OidcFederation === 'function'
-const hasOidcFederation = false
+// `OidcFederationStrategy.create(region, workspaceId, getJwt)` takes the
+// region (`<region>.<provider>`) and workspace id as separate args — both are
+// segments of a CRN like `crn:ap-southeast-2.aws:ZVATKW3VHMFG27DY`.
+function splitCrn(crn: string): { region: string; workspaceId: string } {
+  const match = crn.match(/^crn:([^:]+):(.+)$/)
+  if (!match) {
+    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${crn}`)
+  }
+  return { region: match[1], workspaceId: match[2] }
+}
 
 // ---------------------------------------------------------------------------
-// Hermetic end-to-end — PENDING the auth-package additions described above.
-// ---------------------------------------------------------------------------
-describe.skip('OidcFederation (hermetic, pending auth bump)', () => {
-  test('round-trips encrypt/decrypt via a mocked OIDC exchange', async () => {
-    // const mock = await MockAuthServer.start()
-    // mock.mockOidcExchangeEndpoint()   // upstream addition
-    // mock.mockCreateClientEndpoint()
-    //
-    // const strategy = OidcFederation.createWithBaseUrl(
-    //   { issuer: 'https://issuer.test', audience: 'cipherstash', token: 'fake.id.jwt' },
-    //   mock.baseUrl,                    // test-utils override
-    // )
-    //
-    // const client = await newClient({ encryptConfig, clientOpts, strategy })
-    // const ciphertext = await encrypt(client, {
-    //   plaintext: 'alice@example.com', table: 'users', column: 'email',
-    // })
-    // expect(isEncrypted(ciphertext)).toBe(true)
-    // expect(await decrypt(client, { ciphertext })).toBe('alice@example.com')
-    expect(hasOidcFederation).toBe(true)
-  })
-
-  test('surfaces a rejected OIDC exchange as a client error', async () => {
-    // const mock = await MockAuthServer.start()
-    // mock.mockTokenEndpointError('invalid_grant', 'expired id token')
-    // const strategy = OidcFederation.createWithBaseUrl(/* … */, mock.baseUrl)
-    // await expect(
-    //   newClient({ encryptConfig, clientOpts, strategy }),
-    // ).rejects.toThrow(/invalid_grant|expired/)
-    expect(hasOidcFederation).toBe(true)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Live today — the FFI strategy contract `OidcFederation` plugs into. No
-// credentials or network: the strategy shape is validated, and `getToken`
-// rejections propagate, before any ZeroKMS call. This is the same guarantee
-// `js-strategy.test.ts` proves generically; kept here as an OIDC-labelled
-// anchor so the contract is asserted against the exact `opts.strategy` path
-// the real `OidcFederation` will travel.
+// Contract — no credentials, no network.
 // ---------------------------------------------------------------------------
 describe('OidcFederation strategy contract', () => {
+  test('the published strategy constructs and exposes getToken', () => {
+    // Exercises the real `@cipherstash/auth` factory + signature, not a stand-in.
+    // Region/workspace/JWT are arbitrary — `.create` does no I/O, so this stays
+    // offline; the federation call would only happen on `getToken()`.
+    const strategy = OidcFederationStrategy.create(
+      'ap-southeast-2.aws',
+      'ZVATKW3VHMFG27DY',
+      () => 'third-party.oidc.jwt',
+    )
+
+    expect(typeof strategy.getToken).toBe('function')
+    // It satisfies the FFI's structural `AuthStrategy` contract.
+    const asStrategy: AuthStrategy = strategy
+    expect(asStrategy).toBeDefined()
+  })
+
   test('a rejected getToken propagates as a client error', async () => {
-    // Stand-in for `OidcFederation` until it is exported: any object
-    // satisfying `AuthStrategy` reaches the same native code path.
+    // The OidcFederationStrategy reaches `newClient` through the exact
+    // `opts.strategy` path asserted here; a `getJwt`/federation failure
+    // surfaces as a rejected `getToken`, which must reach the caller. The
+    // strategy guards run before any ZeroKMS call, so no credentials/network.
     const strategy: AuthStrategy = {
       async getToken() {
-        throw new Error('OIDC exchange failed (placeholder for OidcFederation)')
+        throw new Error('OIDC federation exchange failed')
       },
     }
 
     await expect(
       newClient({ encryptConfig, clientOpts, strategy }),
-    ).rejects.toThrow(/OIDC exchange failed/)
+    ).rejects.toThrow(/OIDC federation exchange failed/)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// End-to-end — gated on a real third-party OIDC JWT + dataset credentials.
+//
+// Set CS_OIDC_JWT to a third-party OIDC token the target workspace is
+// configured to federate, plus the usual CS_WORKSPACE_CRN / CS_CLIENT_ID /
+// CS_CLIENT_KEY. Absent any of these the suite is skipped, exactly like the
+// other credentialed suites.
+// ---------------------------------------------------------------------------
+const E2E_ENV = [
+  'CS_OIDC_JWT',
+  'CS_WORKSPACE_CRN',
+  'CS_CLIENT_ID',
+  'CS_CLIENT_KEY',
+] as const
+const missingE2eEnv = E2E_ENV.filter((k) => !process.env[k])
+
+describe.skipIf(missingE2eEnv.length > 0)('OidcFederation end-to-end', () => {
+  test('federates an OIDC JWT and round-trips encrypt/decrypt', async () => {
+    const jwt = process.env.CS_OIDC_JWT
+    const crn = process.env.CS_WORKSPACE_CRN
+    if (!jwt || !crn) {
+      throw new Error('unreachable: skipIf gates this')
+    }
+    const { region, workspaceId } = splitCrn(crn)
+
+    // `getJwt` is re-invoked on every (re-)federation; here it just returns the
+    // pre-minted token from the environment.
+    const strategy = OidcFederationStrategy.create(
+      region,
+      workspaceId,
+      () => jwt,
+    )
+
+    const client = await newClient({ encryptConfig, clientOpts, strategy })
+
+    const plaintext = 'alice@example.com'
+    const ciphertext = await encrypt(client, {
+      plaintext,
+      table: 'users',
+      column: 'email',
+    })
+
+    expect(isEncrypted(ciphertext)).toBe(true)
+    expect(await decrypt(client, { ciphertext })).toBe(plaintext)
   })
 })

--- a/integration-tests/tests/oidc-federation.test.ts
+++ b/integration-tests/tests/oidc-federation.test.ts
@@ -1,4 +1,4 @@
-// Coverage for the `OidcFederation` auth strategy.
+// Contract coverage for the `OidcFederation` auth strategy.
 //
 // `stack-auth` introduced an `OidcFederationStrategy` that federates a
 // third-party OIDC JWT (Clerk, Supabase, …) into a CipherStash CTS service
@@ -8,70 +8,48 @@
 // From protect-ffi's perspective it is just another `opts.strategy`: the
 // native boundary duck-types on the
 // `AuthStrategy = { getToken: () => Promise<{ token: string }> }` contract
-// (see `src/index.cts`) and never branches on the concrete strategy type. So
-// there is nothing new to test on the FFI side — the coverage that matters is
-// consumer-side wiring, mirroring `js-strategy.test.ts` (Neon path) and
-// `wasm-round-trip.test.ts` (wasm path).
+// (see `src/index.cts`) and never branches on the concrete strategy type. The
+// OIDC-specific thing worth asserting here is that the *real published*
+// strategy satisfies that contract — which this test does hermetically, with
+// no credentials and no network.
 //
-// # Two tiers
+// The strategy-agnostic FFI behaviours are already covered elsewhere and not
+// duplicated here:
 //
-//   1. Contract (runs in CI today, no credentials, no network): the real
-//      published `OidcFederationStrategy` constructs via its `.create` factory
-//      and exposes `getToken`, and a `getToken`-shaped strategy threads through
-//      protect-ffi's `newClient` with rejections propagating as client errors.
+//   - That a strategy threads through `newClient` and a rejected `getToken`
+//     propagates to the caller: `js-strategy.test.ts`.
+//   - The FFI ⇄ wasm-strategy ⇄ ZeroKMS encrypt/decrypt path: via
+//     `AccessKeyStrategy` in `wasm-round-trip.test.ts` / `js-strategy.test.ts`.
+//     (The strategy *type* is irrelevant to the FFI, which only calls
+//     `getToken`.)
 //
-//   2. End-to-end (gated on OIDC env): a real federation round-trip —
-//      third-party JWT → CTS token → encrypt → decrypt. `describe.skipIf` keeps
-//      it a no-op until the env vars below are set, matching how every other
-//      credentialed suite behaves.
+// # Why there is no live end-to-end round-trip here
 //
-// A fully *hermetic* round-trip via `@cipherstash/auth`'s `MockAuthServer` is
-// not possible through the published consumer API: the mock is napi-only (the
-// integration tests run on the `wasm-inline` entry) and the public
-// `OidcFederationStrategy.create` exposes no base-URL override to point a
-// strategy at the mock (that override is `test-utils`-gated inside stack-auth
-// and used only by its own internal tests). Hence the live exchange is
-// env-gated rather than mocked.
+// A real federation round-trip (third-party JWT → CTS token → encrypt/decrypt)
+// is deliberately *not* tested in this repo:
+//
+//   - The OIDC-specific part (`getJwt` → `/api/authorise` → CTS token) lives
+//     entirely inside `stack-auth`, which tests it hermetically with its own
+//     `MockAuthServer` + a base-URL override. That override is `test-utils`-
+//     gated and not exposed on the published consumer API, so it cannot be
+//     reproduced here.
+//   - A live round-trip would need a *fresh* third-party OIDC JWT per run (they
+//     expire in minutes), so it can't be driven from a static CI secret without
+//     real IdP infrastructure — and gating it on an env var that CI never sets
+//     would make it permanently skipped: green but inert.
 
-import 'dotenv/config'
 import { OidcFederationStrategy } from '@cipherstash/auth/wasm-inline'
 import { describe, expect, test } from 'vitest'
 
-import {
-  type AuthStrategy,
-  type ClientOpts,
-  decrypt,
-  encrypt,
-  isEncrypted,
-  newClient,
-} from '@cipherstash/protect-ffi'
+import type { AuthStrategy } from '@cipherstash/protect-ffi'
 
-import { encryptConfig } from './common.js'
-
-const clientOpts: ClientOpts = {
-  clientId: process.env.CS_CLIENT_ID,
-  clientKey: process.env.CS_CLIENT_KEY,
-}
-
-// `OidcFederationStrategy.create(region, workspaceId, getJwt)` takes the
-// region (`<region>.<provider>`) and workspace id as separate args — both are
-// segments of a CRN like `crn:ap-southeast-2.aws:ZVATKW3VHMFG27DY`.
-function splitCrn(crn: string): { region: string; workspaceId: string } {
-  const match = crn.match(/^crn:([^:]+):(.+)$/)
-  if (!match) {
-    throw new Error(`unexpected CS_WORKSPACE_CRN format: ${crn}`)
-  }
-  return { region: match[1], workspaceId: match[2] }
-}
-
-// ---------------------------------------------------------------------------
-// Contract — no credentials, no network.
-// ---------------------------------------------------------------------------
 describe('OidcFederation strategy contract', () => {
   test('the published strategy constructs and exposes getToken', () => {
     // Exercises the real `@cipherstash/auth` factory + signature, not a stand-in.
-    // Region/workspace/JWT are arbitrary — `.create` does no I/O, so this stays
-    // offline; the federation call would only happen on `getToken()`.
+    // `OidcFederationStrategy.create(region, workspaceId, getJwt)` takes the
+    // region (`<region>.<provider>`) and workspace id as separate args. Both are
+    // arbitrary here — `.create` does no I/O, so this stays offline; the
+    // federation call would only happen on `getToken()`.
     const strategy = OidcFederationStrategy.create(
       'ap-southeast-2.aws',
       'ZVATKW3VHMFG27DY',
@@ -83,74 +61,5 @@ describe('OidcFederation strategy contract', () => {
     // callable on that contract-typed handle.
     const asStrategy: AuthStrategy = strategy
     expect(typeof asStrategy.getToken).toBe('function')
-  })
-
-  test('a rejected getToken propagates as a client error', async () => {
-    // The OidcFederationStrategy reaches `newClient` through the exact
-    // `opts.strategy` path asserted here; a `getJwt`/federation failure
-    // surfaces as a rejected `getToken`, which must reach the caller. The
-    // strategy guards run before any ZeroKMS call, so no credentials/network.
-    const strategy: AuthStrategy = {
-      async getToken() {
-        throw new Error('OIDC federation exchange failed')
-      },
-    }
-
-    await expect(
-      newClient({ encryptConfig, clientOpts, strategy }),
-    ).rejects.toThrow(/OIDC federation exchange failed/)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// End-to-end — gated on a real third-party OIDC JWT + dataset credentials.
-//
-// Set CS_OIDC_JWT to a third-party OIDC token the target workspace is
-// configured to federate, plus the usual CS_WORKSPACE_CRN / CS_CLIENT_ID /
-// CS_CLIENT_KEY. Absent any of these the suite is skipped, exactly like the
-// other credentialed suites.
-// ---------------------------------------------------------------------------
-const E2E_ENV = [
-  'CS_OIDC_JWT',
-  'CS_WORKSPACE_CRN',
-  'CS_CLIENT_ID',
-  'CS_CLIENT_KEY',
-] as const
-const missingE2eEnv = E2E_ENV.filter((k) => !process.env[k])
-
-describe.skipIf(missingE2eEnv.length > 0)('OidcFederation end-to-end', () => {
-  test('federates an OIDC JWT and round-trips encrypt/decrypt', async () => {
-    const jwt = process.env.CS_OIDC_JWT
-    const crn = process.env.CS_WORKSPACE_CRN
-    if (!jwt || !crn) {
-      throw new Error('unreachable: skipIf gates this')
-    }
-    const { region, workspaceId } = splitCrn(crn)
-
-    // `getJwt` is re-invoked on every (re-)federation; here it just returns the
-    // pre-minted token from the environment.
-    const federation = OidcFederationStrategy.create(
-      region,
-      workspaceId,
-      () => jwt,
-    )
-
-    // Hand the Neon `newClient` a plain `{ getToken }` object rather than the
-    // wasm-bindgen class instance directly. The JsBacked path is proven against
-    // this shape (js-strategy.test.ts); passing a wasm class straight through is
-    // untested. The arrow keeps `getToken` bound to its wasm `this`.
-    const strategy: AuthStrategy = { getToken: () => federation.getToken() }
-
-    const client = await newClient({ encryptConfig, clientOpts, strategy })
-
-    const plaintext = 'alice@example.com'
-    const ciphertext = await encrypt(client, {
-      plaintext,
-      table: 'users',
-      column: 'email',
-    })
-
-    expect(isEncrypted(ciphertext)).toBe(true)
-    expect(await decrypt(client, { ciphertext })).toBe(plaintext)
   })
 })

--- a/integration-tests/tests/wasm-round-trip.test.ts
+++ b/integration-tests/tests/wasm-round-trip.test.ts
@@ -101,15 +101,10 @@ describe.skipIf(missingEnv.length > 0)('wasm round-trip', () => {
       )
     }
 
-    // stack-auth 0.36 dropped CS_REGION in favour of CS_WORKSPACE_CRN.
-    // The wasm AccessKeyStrategy.create still takes a region string but
-    // it expects the `<region>.<provider>` form, which is the middle
-    // segment of a CRN like `crn:ap-southeast-2.aws:<workspace>`.
-    const crnMatch = env.workspaceCrn.match(/^crn:([^:]+):/)
-    if (!crnMatch) {
-      throw new Error(`unexpected CS_WORKSPACE_CRN format: ${env.workspaceCrn}`)
-    }
-    const strategy = AccessKeyStrategy.create(crnMatch[1], env.accessKey)
+    // @cipherstash/auth 0.39 takes the full workspace CRN and parses the
+    // region from it (earlier versions took only the `<region>.<provider>`
+    // segment, requiring callers to split the CRN themselves).
+    const strategy = AccessKeyStrategy.create(env.workspaceCrn, env.accessKey)
 
     const client = await wasm.newClient({
       strategy,


### PR DESCRIPTION
## Summary

Updates `cipherstash-client` and `stack-auth` to `0.37.0`. Also bumps the lockstep crates `cts-common` and `stack-profile` to `0.37.0` so the dependency tree doesn't end up with duplicate `0.36`/`0.37` copies (`cipherstash-client` 0.37 pulls in the 0.37 versions transitively).

Transitive bumps that came along: `cipherstash-config`, `cipherstash-core` → `0.37.0`, `zerokms-protocol` → `0.12.17`.

This branch also includes the OIDC federation test coverage from #101 (merged in): bumps `@cipherstash/auth` to `^0.39.0` and adds `OidcFederationStrategy` contract tests, plus the `AccessKeyStrategy.create` full-CRN update across the existing strategy suites.

## Testing

- `cargo test` — 71 passed
- `npm run build:wasm` — clean build + inline shim generated
- **Full integration suite is green in CI** (see the Tests check) — including `tests/keyset.test.ts`.

### Local-only keyset failures (these pass in CI)

Running `mise run test:integration:all` **locally** shows 2 failures in `tests/keyset.test.ts` (`Failed to load keyset: NotFound`). They reproduce only against local credentials — root cause is a workspace-permission gap, visible in `beforeAll`:

```
Warning: grant_keyset failed (may be already granted): Failed to send request: Forbidden: Request forbidden
```

The local credentials can't provision/grant the `Test` keyset. CI runs with workspace credentials that can, so those tests — and the whole suite — pass green in CI. Either way it's environment/access-control related and independent of the version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped several internal dependency versions to current releases for compatibility and stability.
* **Tests**
  * Added integration coverage for OIDC federation auth.
  * Updated integration tests and fixtures to align auth strategy construction with the current workspace identifier format and improve wasm/JS auth strategy checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->